### PR TITLE
`omnix-cli`: Initialize CLI argument handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,6 @@ jobs:
           nixci \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
             build --systems "path:$HOME/systems"
+      - name: Run CLI
+        run: |
+          nix run .#omnix-cli -- --help

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,6 +2905,11 @@ dependencies = [
 [[package]]
 name = "omnix-cli"
 version = "0.1.0"
+dependencies = [
+ "clap",
+ "omnix",
+ "tracing",
+]
 
 [[package]]
 name = "omnix-gui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/omnix", "crates/omnix-cli", "crates/omnix-gui"]
 anyhow = "1.0.75"
 bytesize = { version = "1.3.0", features = ["serde"] }
 cfg-if = "1"
-clap = "4.3"
+clap = { version = "4.3", features = ["derive", "env"] }
 console_error_panic_hook = "0.1"
 console_log = "1"
 direnv = "0.1.1"

--- a/crates/omnix-cli/Cargo.toml
+++ b/crates/omnix-cli/Cargo.toml
@@ -2,5 +2,9 @@
 name = "omnix-cli"
 version = "0.1.0"
 edition = "2021"
+default-run = "omnix-cli"
 
 [dependencies]
+clap = { workspace = true }
+omnix = { workspace = true }
+tracing = { workspace = true }

--- a/crates/omnix-cli/src/command/init.rs
+++ b/crates/omnix-cli/src/command/init.rs
@@ -1,0 +1,4 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct InitConfig {}

--- a/crates/omnix-cli/src/command/mod.rs
+++ b/crates/omnix-cli/src/command/mod.rs
@@ -1,0 +1,13 @@
+use clap::Subcommand;
+
+pub mod init;
+pub mod show;
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Inspect a flake
+    Show(show::ShowConfig),
+
+    /// Initialize a flake
+    Init(init::InitConfig),
+}

--- a/crates/omnix-cli/src/command/show.rs
+++ b/crates/omnix-cli/src/command/show.rs
@@ -1,0 +1,4 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct ShowConfig {}

--- a/crates/omnix-cli/src/main.rs
+++ b/crates/omnix-cli/src/main.rs
@@ -1,3 +1,21 @@
+use clap::Parser;
+
+mod command;
+
+// NOTE: Should we put this in `omnix` crate, and share with `omnix-gui` (see
+// `omnix-gui/src/cli.rs`)?
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[command(flatten)]
+    pub verbosity: omnix::logging::Verbosity,
+
+    #[clap(subcommand)]
+    pub command: command::Command,
+}
+
 fn main() {
-    println!("Hello, world!");
+    let args = Args::parse();
+    omnix::logging::setup_logging(&args.verbosity);
+    tracing::debug!("Args: {:?}", args);
+    tracing::info!("Hello from omnix-cli");
 }

--- a/crates/omnix/src/logging.rs
+++ b/crates/omnix/src/logging.rs
@@ -1,5 +1,6 @@
 //! Logging setup for omnix
 
+use clap;
 use tracing_subscriber::filter::{Directive, LevelFilter};
 use tracing_subscriber::EnvFilter;
 

--- a/justfile
+++ b/justfile
@@ -15,13 +15,19 @@ bundle $CI="true":
     cd ./crates/omnix-gui/assets && dx bundle --release
     nix run nixpkgs#lsd -- --tree ./dist/bundle/macos/omnix-gui.app
 
-# Run the project locally
+# Run omnix-gui locally
 watch $RUST_BACKTRACE="1":
     # XXX: hot reload doesn't work with tailwind
     # dx serve --hot-reload
     cd ./crates/omnix-gui && dx serve --bin omnix-gui
 
 alias w := watch
+
+# Run omnix-cli locally
+watch-cli *ARGS:
+    cargo watch -p omnix-cli -x 'run -- {{ARGS}}'
+
+alias wc := watch-cli
 
 # Run tests
 test:


### PR DESCRIPTION
Introduces `clap` crate, and stubs out `init` and `show` commands for #140 