### PR TITLE
health: Initialize `om health`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "nix_health",
+ "nix_rs",
  "omnix",
  "tokio",
  "tracing",

--- a/crates/omnix-cli/Cargo.toml
+++ b/crates/omnix-cli/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+nix_health = { workspace = true }
+nix_rs = { workspace = true }
 omnix = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/omnix-cli/src/command/health.rs
+++ b/crates/omnix-cli/src/command/health.rs
@@ -1,11 +1,35 @@
 use clap::Parser;
+use nix_health::{run_checks_with, NixHealth};
+use nix_rs::flake::url::FlakeUrl;
 
 #[derive(Parser, Debug)]
-pub struct HealthConfig {}
+pub struct HealthConfig {
+    /// Include health checks defined in the given flake
+    pub flake_url: Option<FlakeUrl>,
+
+    /// Be quiet by outputting only failed checks
+    #[arg(long = "quiet", short = 'q')]
+    pub quiet: bool,
+
+    /// Dump the config schema of the health checks (useful when adding them to
+    /// a flake.nix)
+    #[arg(long = "dump-schema")]
+    pub dump_schema: bool,
+}
 
 impl HealthConfig {
     pub async fn run(&self) -> anyhow::Result<()> {
-        tracing::info!("TODO(om health): {:?}", self);
+        if self.dump_schema {
+            tracing::info!("{}", NixHealth::schema()?);
+            return Ok(());
+        }
+        // TODO: Setup logging (unify `crates/nix_health/src/logging.rs` and `crates/omnix/src/logging.rs`)
+        // TODO: `om.health` config?
+        let checks = run_checks_with(self.flake_url.clone()).await?;
+        let exit_code = NixHealth::print_report_returning_exit_code(&checks);
+        if exit_code != 0 {
+            std::process::exit(exit_code);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Runs nix-health, but doesn't configure logging yet.

<img width="957" alt="image" src="https://github.com/user-attachments/assets/a75aa23b-3628-400c-8d94-5873a6644002">
