### PR TITLE
health: Recognize `om.health` from flake.nix

### DIFF
--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- **eval**
+  - `nix_eval_attr_json`: No longer takes `default_if_missing`; instead (always) returns `None` if attribute is missing.
+
 ## [0.5.0](https://github.com/juspay/nix-rs/compare/0.4.0...0.5.0) (2024-06-05)
 
 ### Features

--- a/crates/omnix-cli/src/command/health.rs
+++ b/crates/omnix-cli/src/command/health.rs
@@ -4,7 +4,8 @@ use nix_rs::flake::url::FlakeUrl;
 
 #[derive(Parser, Debug)]
 pub struct HealthConfig {
-    /// Include health checks defined in the given flake
+    /// Use `om.health` configuration from the given flake
+    #[arg(name = "FLAKE")]
     pub flake_url: Option<FlakeUrl>,
 
     /// Dump the config schema of the health checks (useful when adding them to
@@ -19,8 +20,6 @@ impl HealthConfig {
             tracing::info!("{}", NixHealth::schema()?);
             return Ok(());
         }
-        // TODO: Setup logging (unify `crates/nix_health/src/logging.rs` and `crates/omnix/src/logging.rs`)
-        // TODO: `om.health` config?
         let checks = run_checks_with(self.flake_url.clone()).await?;
         let exit_code = NixHealth::print_report_returning_exit_code(&checks);
         if exit_code != 0 {

--- a/crates/omnix-cli/src/command/mod.rs
+++ b/crates/omnix-cli/src/command/mod.rs
@@ -16,7 +16,7 @@ pub enum Command {
     /// Build all flake outputs (run CI locally)
     CI(ci::CIConfig),
 
-    /// Show Nix's health
+    /// Display the health of your system environment as suited for Nix
     Health(health::HealthConfig),
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,8 +26,9 @@
         ./crates/nix_health/module/flake-module.nix
       ];
 
-      flake = {
-        nix-health.default = {
+      # omnix configuration
+      flake.om = {
+        health.default = {
           nix-version.min-required = "2.16.0";
           # We don't use a Nix cache yet
           # caches.required = [ "https://cache.juspay.dev" ];


### PR DESCRIPTION
In addition to `nix-health.default`, `om health` will now also recognize `om.health.default`.

Down the line, we may as well deprecate and remove `nix-health.default`.

#153 
