### PR TITLE
Add CLI integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         system: [ x86_64-linux, aarch64-darwin ]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - name: Build
@@ -26,6 +27,8 @@ jobs:
           nixci \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
             build --systems "path:$HOME/systems"
-      - name: Run
+      - name: CLI Tests
         run: |
-          nix run .#ci
+          # We disable tests on Nix due to sandboxing issues.
+          cd ./crates/omnix-cli
+          nix develop -c cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +429,17 @@ dependencies = [
  "futures-lite",
  "piper",
  "tracing",
+]
+
+[[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.3",
+ "serde",
 ]
 
 [[package]]
@@ -1004,6 +1030,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1662,15 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2796,6 +2843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,12 +2970,14 @@ name = "omnix-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "clap-verbosity-flag",
  "human-panic",
  "nix_health",
  "nix_rs",
  "omnix",
+ "predicates",
  "tokio",
  "tracing",
 ]
@@ -3275,6 +3330,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -4184,6 +4269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4524,6 +4615,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **eval**
   - `nix_eval_attr_json`: No longer takes `default_if_missing`; instead (always) returns `None` if attribute is missing.
+- **`NixEnv`**
+  - Clarify error message when `$USER` is not set
 
 ## [0.5.0](https://github.com/juspay/nix-rs/compare/0.4.0...0.5.0) (2024-06-05)
 

--- a/crates/nix_rs/src/env.rs
+++ b/crates/nix_rs/src/env.rs
@@ -200,8 +200,8 @@ impl OS {
 
 #[derive(thiserror::Error, Debug)]
 pub enum NixEnvError {
-    #[error("Environment error: {0}")]
-    EnvVarError(#[from] std::env::VarError),
+    #[error("Cannot find $USER: {0}")]
+    UserError(#[from] std::env::VarError),
 
     #[error("Failed to fetch groups: {0}")]
     GroupsError(std::io::Error),

--- a/crates/omnix-cli/Cargo.toml
+++ b/crates/omnix-cli/Cargo.toml
@@ -18,3 +18,8 @@ nix_rs = { workspace = true }
 omnix = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+anyhow = { workspace = true }

--- a/crates/omnix-cli/tests/cli.rs
+++ b/crates/omnix-cli/tests/cli.rs
@@ -1,0 +1,25 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+/// `om --help` works
+#[test]
+fn om_help() -> anyhow::Result<()> {
+    om()?.arg("--help").assert().success();
+    Ok(())
+}
+
+/// `om health` runs, and succeeds.
+#[test]
+fn om_health() -> anyhow::Result<()> {
+    om()?.arg("health").assert().success().stdout(
+        predicate::str::contains("All checks passed")
+            .or(predicate::str::contains("Required checks passed")),
+    );
+    Ok(())
+}
+
+/// Return the [Command] pointing to the `om` cargo bin
+fn om() -> anyhow::Result<Command> {
+    Ok(Command::cargo_bin("om")?)
+}

--- a/flake.nix
+++ b/flake.nix
@@ -52,21 +52,6 @@
           };
         };
 
-        # Extra things to run in CI, on top of nixci
-        apps.ci.program = pkgs.writeShellApplication {
-          name = "ci-extra";
-          runtimeInputs = [ self'.packages.default ];
-          text = ''
-            om --help
-
-            # Test `om health`
-            om health
-          '';
-          # TODO: Upstream this to nixci?
-          # https://github.com/srid/nixci/issues/86
-          meta.nixci.run = true;
-        };
-
         devShells.default = pkgs.mkShell {
           name = "omnix";
           inputsFrom = [

--- a/justfile
+++ b/justfile
@@ -33,6 +33,9 @@ alias w := watch
 test:
     cargo test
 
+test-cli:
+    cd ./crates/omnix-cli && cargo watch -x test
+
 # Run docs server (live reloading)
 doc:
     cargo-doc-live

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -37,6 +37,9 @@
               nativeBuildInputs = with pkgs;[
                 pkg-config
               ];
+              # Disable tests due to sandboxing issues; we run them on CI
+              # instead.
+              doCheck = false;
               meta = {
                 description = "Command-line interface for Omnix";
                 mainProgram = "om";


### PR DESCRIPTION
Instead of testing the CLI in bash, test them the Rust way.

cf. 

- [Test Organization > Integration Tests](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests)
- [Testing CLI applications by running them](https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them)

Note that these tests are not run during Nix build due to sandboxing issues (`NixEnv` detection fails), so we run them separately in CI.