### PR TITLE
Fix doc warnings, and check them in CI

### DIFF
--- a/crates/nix_health/src/check/trusted_users.rs
+++ b/crates/nix_health/src/check/trusted_users.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::traits::*;
 
-/// Check that [crate::nix::config::NixConfig::trusted_users] is set to a good value.
+/// Check that [nix_rs::config::NixConfig::trusted_users] is set to a good value.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct TrustedUsers {}

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -23,7 +23,7 @@ use self::check::{
 
 /// Nix Health check information for user's install
 ///
-/// Each field represents an individual check which satisfies the [Checkable] trait.
+/// Each field represents an individual check which satisfies the [traits::Checkable] trait.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct NixHealth {

--- a/crates/nix_rs/src/env.rs
+++ b/crates/nix_rs/src/env.rs
@@ -87,11 +87,11 @@ fn get_nix_disk(sys: &sysinfo::System) -> Result<&sysinfo::Disk, NixEnvError> {
 pub enum OS {
     /// On macOS
     MacOS {
-        /// Using https://github.com/LnL7/nix-darwin
+        /// Using nix-darwin
         nix_darwin: bool,
         arch: MacOSArch,
     },
-    /// https://nixos.org/
+    /// On NixOS
     NixOS,
     /// Nix is individually installed on Linux or macOS
     Other(os_info::Type),

--- a/crates/omnix-gui/src/app/state/mod.rs
+++ b/crates/omnix-gui/src/app/state/mod.rs
@@ -19,8 +19,6 @@ use self::{datum::Datum, error::SystemError, refresh::Refresh};
 ///
 /// They use [Datum] which is a glorified [Option] to distinguish between initial
 /// loading and subsequent refreshing.
-///
-/// Use [Action] to mutate this state, in addition to [Signal::set].
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct AppState {
     /// [NixInfo] as detected on the user's system

--- a/crates/omnix-gui/src/app/widget.rs
+++ b/crates/omnix-gui/src/app/widget.rs
@@ -5,8 +5,6 @@ use std::path::PathBuf;
 use dioxus::prelude::*;
 
 /// A refresh button with a busy indicator
-///
-/// You want to use [crate::state::datum] for this.
 pub fn RefreshButton<F: 'static + FnMut(Event<MouseData>)>(busy: bool, mut handler: F) -> Element {
     rsx! {
         button {
@@ -27,7 +25,7 @@ pub fn RefreshButton<F: 'static + FnMut(Event<MouseData>)>(busy: bool, mut handl
 /// Note: You can only select a single folder.
 ///
 /// NOTE(for future): When migrating to Dioxus using Tauri 2.0, switch to using
-/// https://github.com/tauri-apps/tauri-plugin-dialog
+/// <https://github.com/tauri-apps/tauri-plugin-dialog>
 // #[component]
 pub fn FolderDialogButton<F: 'static + FnMut(PathBuf)>(mut handler: F) -> Element {
     // FIXME: The id should be unique if this widget is used multiple times on

--- a/flake.lock
+++ b/flake.lock
@@ -100,22 +100,6 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "process-compose-flake": {
       "locked": {
         "lastModified": 1718031437,
@@ -151,15 +135,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1720970456,
-        "narHash": "sha256-FU3lrSHj16WWyW/L/fGY9SEs6lfszo1YOEWUV+M9iU0=",
+        "lastModified": 1721248389,
+        "narHash": "sha256-p/HO8YAsGGFQ8EnYaVMgl8AiqenA4r0cIGJ6mZACpFA=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "0324dc2606adc453f7c1faeb9ab8ed5b26e084af",
+        "rev": "3fab5d19cc8c63e97271a736d0de105c9174255a",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
+        "ref": "doc-warnings",
         "repo": "rust-flake",
         "type": "github"
       }
@@ -167,7 +152,10 @@
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "rust-flake",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1715480255,

--- a/flake.lock
+++ b/flake.lock
@@ -135,16 +135,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1721248389,
+        "lastModified": 1721249094,
         "narHash": "sha256-p/HO8YAsGGFQ8EnYaVMgl8AiqenA4r0cIGJ6mZACpFA=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "3fab5d19cc8c63e97271a736d0de105c9174255a",
+        "rev": "658edce0b6bb521f1f54957ddbfab80f73066bee",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
-        "ref": "doc-warnings",
         "repo": "rust-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
 
-    rust-flake.url = "github:juspay/rust-flake";
+    rust-flake.url = "github:juspay/rust-flake/doc-warnings";
     rust-flake.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
 
-    rust-flake.url = "github:juspay/rust-flake/doc-warnings";
+    rust-flake.url = "github:juspay/rust-flake";
     rust-flake.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
The `-doc` package will now fail build if there are warnings in Rust docs: https://github.com/juspay/rust-flake/pull/18