### PR TITLE
`om init`: Use `om.templates` for non-standard config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,11 @@ jobs:
           nixci \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
             build --systems "path:$HOME/systems"
+      # In lieu of https://github.com/srid/nixci/issues/88
+      - name: Registry flake check
+        run: |
+          cd ./crates/flakreate/registry
+          nix flake check
       - name: CLI Tests
         run: |
           # We disable tests on Nix due to sandboxing issues.

--- a/crates/flakreate/registry/flake.lock
+++ b/crates/flakreate/registry/flake.lock
@@ -170,7 +170,6 @@
       }
     },
     "haskell-flake": {
-      "flake": false,
       "locked": {
         "lastModified": 1721530802,
         "narHash": "sha256-eUMmQKXjt4WQq+IBscftg/Y9bXWiOYhasfeH5Yb9Psc=",
@@ -368,11 +367,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721559948,
-        "narHash": "sha256-cFgdjyK/VBM3hB1RfFHXcI/VOCBVAv813s1upHKX7bI=",
+        "lastModified": 1721622093,
+        "narHash": "sha256-iQ+quy3A1EKeFyLyAtjhgSvZHH7r+xybXZkxMhasN4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c19d62ad2265b16e2199c5feb4650fe459ca1c46",
+        "rev": "453402b94f39f968a7c27df28e060f69e4a50c3b",
         "type": "github"
       },
       "original": {

--- a/crates/flakreate/registry/flake.nix
+++ b/crates/flakreate/registry/flake.nix
@@ -7,7 +7,6 @@
     # Pull templates from external flake-parts modules
     # The pull happens in CI periodically.
     haskell-flake.url = "github:srid/haskell-flake";
-    haskell-flake.flake = false;
     haskell-template.url = "github:srid/haskell-template";
     haskell-template.flake = false;
     nix-dev-home.url = "github:juspay/nix-dev-home";
@@ -16,10 +15,19 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.systems;
       flake = {
+        templates = {
+          nix-dev-home = inputs.nix-dev-home.templates.default;
+          haskell-flake = inputs.haskell-flake.templates.example;
+          haskell-template = {
+            # TODO: Upstream?
+            description = "A batteries-included Haskell project template";
+            path = builtins.path { path = inputs.haskell-template; };
+          };
+        };
         # TODO: Ideally, these params should be moved to upstream module.
         # But do that only as the spec stabilizes.
-        templates = rec {
-          nix-dev-home = inputs.nix-dev-home.templates.default // {
+        om.templates = {
+          nix-dev-home = {
             tags = [ "home-manager" "juspay" "development" ];
             params = [
               {
@@ -60,8 +68,6 @@
             ];
           };
           haskell-flake = {
-            description = "Haskell project template, using haskell-flake";
-            path = builtins.path { path = inputs.haskell-flake + /example; };
             tags = [ "haskell" "haskell-flake" ];
             params = [
               {
@@ -77,8 +83,6 @@
             ];
           };
           haskell-template = {
-            description = "A batteries-included Haskell project template";
-            path = builtins.path { path = inputs.haskell-template; };
             tags = [ "haskell" "haskell-flake" "relude" "just" ];
             params = [
               {

--- a/crates/flakreate/src/flake_template/mod.rs
+++ b/crates/flakreate/src/flake_template/mod.rs
@@ -84,9 +84,10 @@ pub async fn fetch(url: &FlakeUrl) -> Result<Vec<FlakeTemplate>, NixCmdError> {
     >(nixcmd().await, &url.with_attr("om.templates"))
     .await?
     .unwrap_or_default();
-    // Set 'name' field in each template
     for (name, template) in templates.iter_mut() {
+        // Set 'name' field in each template
         template.name.clone_from(name);
+        // Pull in `om.templates` configuration
         template.config = templates_config.get(name).cloned().unwrap_or_default();
     }
     Ok(templates.values().cloned().collect())

--- a/crates/flakreate/src/flake_template/mod.rs
+++ b/crates/flakreate/src/flake_template/mod.rs
@@ -23,9 +23,6 @@ pub struct FlakeTemplate {
     #[serde(skip_deserializing)]
     pub name: String,
 
-    #[serde(default)]
-    pub tags: Vec<String>,
-
     pub description: String,
 
     pub path: String,
@@ -33,26 +30,45 @@ pub struct FlakeTemplate {
     #[serde(rename = "welcomeText")]
     pub welcome_text: Option<String>,
 
-    pub params: Vec<Param>,
+    #[serde(skip_deserializing)]
+    pub config: FlakeTemplateConfig,
 }
 
 impl Display for FlakeTemplate {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if self.tags.is_empty() {
+        if self.config.tags.is_empty() {
             write!(f, "{}", self.name)
         } else {
-            write!(f, "{:<20} {}", self.name, self.tags.join(", ").dimmed())
+            write!(
+                f,
+                "{:<20} {}",
+                self.name,
+                self.config.tags.join(", ").dimmed()
+            )
         }
     }
 }
 
 impl FlakeTemplate {
     pub fn prompt_replacements(&self) -> anyhow::Result<Vec<Vec<FileOp>>> {
-        self.params
+        self.config
+            .params
             .iter()
             .map(|param| param.prompt_value())
             .collect()
     }
+}
+
+/// Custom flake properties not supported by Nix itself.
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct FlakeTemplateConfig {
+    #[serde(skip_deserializing)]
+    pub name: String,
+
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    pub params: Vec<Param>,
 }
 
 /// Fetch the templates defined in a flake
@@ -63,9 +79,15 @@ pub async fn fetch(url: &FlakeUrl) -> Result<Vec<FlakeTemplate>, NixCmdError> {
     )
     .await?
     .unwrap_or_default();
+    let templates_config = nix_rs::flake::eval::nix_eval_attr_json::<
+        BTreeMap<String, FlakeTemplateConfig>,
+    >(nixcmd().await, &url.with_attr("om.templates"))
+    .await?
+    .unwrap_or_default();
     // Set 'name' field in each template
     for (name, template) in templates.iter_mut() {
         template.name.clone_from(name);
+        template.config = templates_config.get(name).cloned().unwrap_or_default();
     }
     Ok(templates.values().cloned().collect())
 }

--- a/flake.nix
+++ b/flake.nix
@@ -41,11 +41,6 @@
         };
       };
 
-      flake.nixci.default = {
-        omnix.dir = ./.;
-        flakreate-registry.dir = ./crates/flakreate/registry;
-      };
-
       perSystem = { config, self', pkgs, lib, system, ... }: {
         # Add your auto-formatters here.
         # cf. https://nixos.asia/en/treefmt

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,11 @@
         };
       };
 
+      flake.nixci.default = {
+        omnix.dir = ./.;
+        flakreate-registry.dir = ./crates/flakreate/registry;
+      };
+
       perSystem = { config, self', pkgs, lib, system, ... }: {
         # Add your auto-formatters here.
         # cf. https://nixos.asia/en/treefmt


### PR DESCRIPTION
Template config is still in this repo. Will upstream them soon.