### PR TITLE
`om init`: Flesh out CLI test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,7 +930,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -1714,7 +1720,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.0",
  "rustc_version",
 ]
 
@@ -2842,6 +2848,15 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -2935,6 +2950,20 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -2942,7 +2971,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -3138,6 +3167,7 @@ dependencies = [
  "nix_rs",
  "omnix",
  "predicates",
+ "rexpect",
  "tabled",
  "tokio",
  "tracing",
@@ -3804,6 +3834,19 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rexpect"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ff60778f96fb5a48adbe421d21bf6578ed58c0872d712e7e08593c195adff8"
+dependencies = [
+ "comma",
+ "nix 0.25.1",
+ "regex",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "rfd"
@@ -4726,7 +4769,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.0",
  "tempfile",
  "winapi",
 ]
@@ -5528,7 +5571,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.27.1",
  "ordered-stream",
  "rand 0.8.5",
  "serde",

--- a/crates/omnix-cli/Cargo.toml
+++ b/crates/omnix-cli/Cargo.toml
@@ -23,7 +23,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 assert_cmd = "2"
 assert_fs = "1"
 predicates = "3"
-anyhow = { workspace = true }
+rexpect = "0.5"

--- a/crates/omnix-cli/tests/cli.rs
+++ b/crates/omnix-cli/tests/cli.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use rexpect::spawn;
 
 /// `om --help` works
 #[test]
@@ -46,16 +47,34 @@ fn om_show_remote() -> anyhow::Result<()> {
 }
 
 /// `om init` runs and successfully initializes a template
-///
-/// NOTE: Test ignored due to https://github.com/mikaelmello/inquire/issues/71
-///
-/// Alternatively, we can pass all prompt data via CLI args, as JSON. But this
-/// may be overkill.
-#[ignore]
 #[test]
 fn om_init() -> anyhow::Result<()> {
     let temp_dir = assert_fs::TempDir::new().unwrap();
-    om()?.arg("init").arg(temp_dir.path()).assert().success();
+
+    // We can't use `om()`; see https://github.com/mikaelmello/inquire/issues/71
+    // om()?.arg("init").arg(temp_dir.path()).assert().success();
+    let om = assert_cmd::cargo::cargo_bin("om");
+
+    let mut p = spawn(
+        &format!("{:?} init {}", om, temp_dir.path().display()),
+        Some(30_000),
+    )?;
+    p.exp_string("Select a template")?;
+    p.send_line("haskell-template")?;
+    p.exp_string("Package Name")?;
+    p.send_line("foo")?;
+    p.exp_string("Author")?;
+    p.send_line("")?;
+    p.exp_string("VSCode support")?;
+    p.send_line("")?;
+    p.exp_string("Nix Template")?;
+    p.send_line("")?;
+    p.exp_string("GitHub Actions")?;
+    p.send_line("")?;
+
+    // TODO: Run the generated template, and compare output.
+    // Is there a better way of doing these checks? Property tests + ?
+
     temp_dir.close().unwrap();
     Ok(())
 }


### PR DESCRIPTION
Basic tests for now.

With `inquire` we have no choice but to use the `rexpect` crate; see https://github.com/mikaelmello/inquire/issues/71#issuecomment-1977138491