### PR TITLE
nix_rs: Add static data for `NixCmd`, `NixConfig`, `NixInfo`

### DIFF
--- a/crates/flakreate/src/lib.rs
+++ b/crates/flakreate/src/lib.rs
@@ -6,18 +6,8 @@ use std::path::PathBuf;
 
 use nix_rs::command::NixCmd;
 use nix_rs::flake::url::FlakeUrl;
-use tokio::sync::OnceCell;
 
 use crate::{flake_template::fileop::FileOp, registry::FlakeTemplateRegistry};
-
-static NIXCMD: OnceCell<NixCmd> = OnceCell::const_new();
-
-/// TODO: Can we normalize this across omnix-cli?
-async fn nixcmd() -> &'static NixCmd {
-    NIXCMD
-        .get_or_init(|| async { NixCmd::default().with_flakes().await.unwrap() })
-        .await
-}
 
 pub async fn flakreate(registry: FlakeUrl, path: PathBuf) -> anyhow::Result<()> {
     println!(
@@ -36,7 +26,7 @@ pub async fn flakreate(registry: FlakeUrl, path: PathBuf) -> anyhow::Result<()> 
     // Create the flake templatge
     let template_url = registry.with_attr(&template.name);
     println!("$ nix flake new {} -t {}", path, template_url);
-    nixcmd()
+    NixCmd::get()
         .await
         .run_with_args(&["flake", "new", &path, "-t", &template_url.0])
         .await?;

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -131,8 +131,9 @@ impl NixHealth {
 
 /// Run health checks, optionally using the given flake's configuration
 pub async fn run_checks_with(flake_url: Option<FlakeUrl>) -> anyhow::Result<Vec<Check>> {
-    let nix_info = NixInfo::from_nix(NixCmd::get().await)
+    let nix_info = NixInfo::get()
         .await
+        .as_ref()
         .with_context(|| "Unable to gather nix info")?;
     let action_msg = format!(
         "🩺️ Checking the health of your Nix setup ({} on {})",
@@ -148,7 +149,7 @@ pub async fn run_checks_with(flake_url: Option<FlakeUrl>) -> anyhow::Result<Vec<
             Ok(NixHealth::default())
         }
     }?;
-    let checks = health.run_checks(&nix_info, flake_url.clone());
+    let checks = health.run_checks(nix_info, flake_url.clone());
     Ok(checks)
 }
 

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -63,12 +63,12 @@ impl NixHealth {
     /// Fallback to using the default health check config if the flake doesn't
     /// override it.
     pub async fn from_flake(url: &FlakeUrl) -> Result<Self, nix_rs::command::NixCmdError> {
-        let cmd = NixCmd::default();
-        let v = nix_eval_attr_json(&cmd, &url.with_fully_qualified_root_attr("om.health")).await?;
+        let cmd = NixCmd::get().await;
+        let v = nix_eval_attr_json(cmd, &url.with_fully_qualified_root_attr("om.health")).await?;
         match v {
             Some(v) => Ok(v),
             None => {
-                let v = nix_eval_attr_json(&cmd, &url.with_fully_qualified_root_attr("nix-health"))
+                let v = nix_eval_attr_json(cmd, &url.with_fully_qualified_root_attr("nix-health"))
                     .await?;
                 Ok(v.unwrap_or_default())
             }
@@ -131,7 +131,7 @@ impl NixHealth {
 
 /// Run health checks, optionally using the given flake's configuration
 pub async fn run_checks_with(flake_url: Option<FlakeUrl>) -> anyhow::Result<Vec<Check>> {
-    let nix_info = NixInfo::from_nix(&NixCmd::default())
+    let nix_info = NixInfo::from_nix(NixCmd::get().await)
         .await
         .with_context(|| "Unable to gather nix info")?;
     let action_msg = format!(

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -13,6 +13,8 @@
 - **``command`**
   - Add `NixCmd::get()` to return flakes-enabled global command
   - `NixCmd::default()` returns the bare command (no experimental features enabled)
+- ``config``
+  - Add `NixConfig::get()` to get the once-created static value of `NixConfig`
 
 ## [0.5.0](https://github.com/juspay/nix-rs/compare/0.4.0...0.5.0) (2024-06-05)
 

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -16,6 +16,9 @@
   - `NixCmd::default()` returns the bare command (no experimental features enabled)
 - ``config``
   - Add `NixConfig::get()` to get the once-created static value of `NixConfig`
+- `info`
+  - Add `NixInfo::get()` to get the once-created static value of `NixInfo`
+  - Rename `NixInfo::from_nix()` to `NixInfo::new()`; the latter explicitly takes `NixConfig`
 
 ## [0.5.0](https://github.com/juspay/nix-rs/compare/0.4.0...0.5.0) (2024-06-05)
 

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Clarify error message when `$USER` is not set
 - **``command`**
   - Add `NixCmd::get()` to return flakes-enabled global command
+  - `NixCmd::default()` returns the bare command (no experimental features enabled)
 
 ## [0.5.0](https://github.com/juspay/nix-rs/compare/0.4.0...0.5.0) (2024-06-05)
 

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **`flake::schema::FlakeSchema`**
   - Add `nixos_configurations`
 - **`flake::url`**
+  - `Flake::from_nix` explicitly takes `NixConfig` as argument, rather than implicitly running nix to get it.
   - Remove string convertion implementations; use `std::parse` instead, and handle errors explicitly.
 - **`eval`**
   - `nix_eval_attr_json`: No longer takes `default_if_missing`; instead (always) returns `None` if attribute is missing.

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -10,6 +10,8 @@
   - `nix_eval_attr_json`: No longer takes `default_if_missing`; instead (always) returns `None` if attribute is missing.
 - **`env::NixEnv`**
   - Clarify error message when `$USER` is not set
+- **``command`**
+  - Add `NixCmd::get()` to return flakes-enabled global command
 
 ## [0.5.0](https://github.com/juspay/nix-rs/compare/0.4.0...0.5.0) (2024-06-05)
 

--- a/crates/nix_rs/src/command.rs
+++ b/crates/nix_rs/src/command.rs
@@ -41,12 +41,12 @@ pub struct NixCmd {
 }
 
 impl Default for NixCmd {
-    /// The default `nix` command with flakes already enabled.
+    /// The default `nix` command
     ///
-    /// See [NixCmd::with_flakes] for a smarter version that adds feature options only when necessary.
+    /// See [NixCmd::get] for the flakes enabled version.
     fn default() -> Self {
         Self {
-            extra_experimental_features: vec!["nix-command".to_string(), "flakes".to_string()],
+            extra_experimental_features: vec![],
             extra_access_tokens: vec![],
             refresh: false,
         }

--- a/crates/nix_rs/src/config.rs
+++ b/crates/nix_rs/src/config.rs
@@ -110,7 +110,8 @@ impl FromStr for TrustedUserValue {
 
 #[tokio::test]
 async fn test_nix_config() -> Result<(), crate::command::NixCmdError> {
-    let v = NixConfig::from_nix(&crate::command::NixCmd::default()).await?;
+    let cmd = crate::command::NixCmd::get().await;
+    let v = NixConfig::from_nix(cmd).await?;
     println!("Max Jobs: {}", v.max_jobs.value);
     Ok(())
 }

--- a/crates/nix_rs/src/version.rs
+++ b/crates/nix_rs/src/version.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 
 use tracing::instrument;
 
+use crate::command::NixCmd;
+
 /// Nix version as parsed from `nix --version`
 #[derive(Clone, Copy, PartialOrd, PartialEq, Eq, Debug, SerializeDisplay, DeserializeFromStr)]
 pub struct NixVersion {
@@ -50,10 +52,8 @@ impl NixVersion {
     /// Get the output of `nix --version`
 
     #[instrument(name = "version")]
-    pub async fn from_nix(
-        nix_cmd: &super::command::NixCmd,
-    ) -> Result<NixVersion, super::command::NixCmdError> {
-        let v = nix_cmd
+    pub async fn from_nix() -> Result<NixVersion, super::command::NixCmdError> {
+        let v = NixCmd::default()
             .run_with_args_expecting_fromstr(&["--version"])
             .await?;
         Ok(v)
@@ -68,9 +68,7 @@ impl fmt::Display for NixVersion {
 
 #[tokio::test]
 async fn test_run_nix_version() {
-    let nix_version = NixVersion::from_nix(&crate::command::NixCmd::default())
-        .await
-        .unwrap();
+    let nix_version = NixVersion::from_nix().await.unwrap();
     println!("Nix version: {}", nix_version);
 }
 

--- a/crates/omnix-cli/src/command/show.rs
+++ b/crates/omnix-cli/src/command/show.rs
@@ -85,7 +85,7 @@ impl Row {
 
 impl ShowConfig {
     pub async fn run(&self) -> anyhow::Result<()> {
-        let flake = Flake::from_nix(&NixCmd::default(), self.flake_url.clone())
+        let flake = Flake::from_nix(NixCmd::get().await, self.flake_url.clone())
             .await
             .with_context(|| "Unable to fetch flake")?;
 

--- a/crates/omnix-cli/src/command/show.rs
+++ b/crates/omnix-cli/src/command/show.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use colored::Colorize;
 use nix_rs::{
     command::NixCmd,
+    config::NixConfig,
     flake::{outputs::Val, url::FlakeUrl, Flake},
 };
 use tabled::{
@@ -85,7 +86,9 @@ impl Row {
 
 impl ShowConfig {
     pub async fn run(&self) -> anyhow::Result<()> {
-        let flake = Flake::from_nix(NixCmd::get().await, self.flake_url.clone())
+        let nix_cmd = NixCmd::get().await;
+        let nix_config = NixConfig::get().await.as_ref()?;
+        let flake = Flake::from_nix(nix_cmd, nix_config, self.flake_url.clone())
             .await
             .with_context(|| "Unable to fetch flake")?;
 

--- a/crates/omnix-gui/src/app/state/mod.rs
+++ b/crates/omnix-gui/src/app/state/mod.rs
@@ -9,6 +9,7 @@ use dioxus::prelude::*;
 use dioxus_signals::{Readable, Signal, Writable};
 use nix_health::NixHealth;
 use nix_rs::{
+    config::NixConfig,
     flake::{url::FlakeUrl, Flake},
     info::NixInfo,
 };
@@ -123,7 +124,10 @@ impl AppState {
                     let flake_url_2 = flake_url.clone();
                     tracing::info!("Updating flake [{}] refresh={} ...", &flake_url, refresh);
                     let res = Datum::refresh_with(&mut flake, async move {
-                        Flake::from_nix(nixcmd, flake_url_2)
+                        let nix_config = NixConfig::from_nix(nixcmd)
+                            .await
+                            .map_err(|e| Into::<SystemError>::into(e.to_string()))?;
+                        Flake::from_nix(nixcmd, &nix_config, flake_url_2)
                             .await
                             .map_err(|e| Into::<SystemError>::into(e.to_string()))
                     })


### PR DESCRIPTION
Basically, provide a singleton creator for these structs. 

Change other crates to use this, instead of managing their own static variable.

(When we move nixci over here, we'll do the same for nixci.)