### PR TITLE
Avoid unnecessary rebuilds of Nix package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/cachix-action@v14
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           name: om
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1721249094,
-        "narHash": "sha256-p/HO8YAsGGFQ8EnYaVMgl8AiqenA4r0cIGJ6mZACpFA=",
+        "lastModified": 1722177896,
+        "narHash": "sha256-ckJWzRmYtWD0hQIKJzevaVVRIJxiuZHCoHld0VV9tUM=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "658edce0b6bb521f1f54957ddbfab80f73066bee",
+        "rev": "8c702ae058e03c479bd773cbe5e009de4b775819",
         "type": "github"
       },
       "original": {

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -52,7 +52,7 @@
                   pkgs.pkgsStatic.openssl
                 ];
                 DEVOUR_FLAKE = inputs.devour-flake;
-                OM_INIT_REGISTRY = inputs.self + /crates/flakreate/registry;
+                OM_INIT_REGISTRY = config.rust-project.src + /crates/flakreate/registry;
                 # Disable tests due to sandboxing issues; we run them on CI
                 # instead.
                 doCheck = false;


### PR DESCRIPTION
When irrelevant files, like `./nix/closure-size.nix`, change - the `.#omnix-cli` package is being unnecessarily rebuilt. 

This PR fixes that. The update to rust-flake is not relevant, but the subsequent commit is.