### PR TITLE
nix: Create `./crates/*/crate.nix`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,7 @@
 watch_file \
     nix/modules/*.nix \
+    ./crates/*/crane.nix \
     *.nix \
     rust-toolchain.toml \
     crates/flakreate/registry/flake.*
-use flake
+use flake . --trace-verbose

--- a/crates/flakreate/crate.nix
+++ b/crates/flakreate/crate.nix
@@ -1,0 +1,15 @@
+{ flake
+, pkgs
+, lib
+, ...
+}:
+
+{
+  crane.args = {
+    buildInputs = lib.optionals pkgs.stdenv.isDarwin (
+      with pkgs.apple_sdk_frameworks; [
+        IOKit
+      ]
+    );
+  };
+}

--- a/crates/nix_health/crate.nix
+++ b/crates/nix_health/crate.nix
@@ -1,0 +1,31 @@
+{ flake
+, pkgs
+, lib
+, ...
+}:
+
+let
+  inherit (flake) inputs;
+in
+{
+  autoWire = true;
+  crane = {
+    args = {
+      buildInputs = lib.optionals pkgs.stdenv.isDarwin (
+        with pkgs.apple_sdk_frameworks; [
+          IOKit
+          CoreFoundation
+        ]
+      );
+      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
+      DEFAULT_FLAKE_SCHEMAS = inputs.flake-schemas;
+      nativeBuildInputs = with pkgs; [
+        nix # Tests need nix cli
+      ];
+      meta.mainProgram = "nix-health";
+    } // lib.optionalAttrs pkgs.stdenv.isLinux {
+      CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+      CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+    };
+  };
+}

--- a/crates/nix_rs/crate.nix
+++ b/crates/nix_rs/crate.nix
@@ -1,0 +1,26 @@
+{ flake
+, pkgs
+, lib
+, ...
+}:
+
+let
+  inherit (flake) inputs;
+in
+{
+  autoWire = true;
+  crane = {
+    args = {
+      buildInputs = lib.optionals pkgs.stdenv.isDarwin (
+        with pkgs.apple_sdk_frameworks; [
+          IOKit
+        ]
+      );
+      nativeBuildInputs = with pkgs; [
+        nix # Tests need nix cli
+      ];
+      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
+      DEFAULT_FLAKE_SCHEMAS = inputs.flake-schemas;
+    };
+  };
+}

--- a/crates/nixci/crate.nix
+++ b/crates/nixci/crate.nix
@@ -1,0 +1,32 @@
+{ flake
+, pkgs
+, lib
+, ...
+}:
+
+let
+  inherit (flake) inputs;
+in
+{
+  crane = {
+    args = {
+      nativeBuildInputs = with pkgs; with pkgs.apple_sdk_frameworks; lib.optionals stdenv.isDarwin [
+        Security
+        SystemConfiguration
+      ] ++ [
+        libiconv
+        pkg-config
+      ];
+      buildInputs = lib.optionals pkgs.stdenv.isDarwin
+        (
+          with pkgs.apple_sdk_frameworks; [
+            IOKit
+            CoreFoundation
+          ]
+        ) ++ lib.optionals pkgs.stdenv.isLinux [
+        pkgs.openssl
+      ];
+      DEVOUR_FLAKE = inputs.devour-flake;
+    };
+  };
+}

--- a/crates/omnix-cli/crate.nix
+++ b/crates/omnix-cli/crate.nix
@@ -1,0 +1,54 @@
+{ flake
+, rust-project
+, pkgs
+, lib
+, ...
+}:
+
+let
+  inherit (flake) inputs;
+  inherit (pkgs) stdenv pkgsStatic;
+in
+{
+  autoWire = false;
+  crane = {
+    args = {
+      nativeBuildInputs = with pkgs.apple_sdk_frameworks; lib.optionals stdenv.isDarwin [
+        Security
+        SystemConfiguration
+      ] ++ [
+        # Packages from `pkgsStatic` require cross-compilation support for the target platform,
+        # which is not yet available for `x86_64-apple-darwin` in nixpkgs. Upon trying to evaluate
+        # a static package for `x86_64-apple-darwin`, you may see an error like:
+        #
+        # > error: don't yet have a `targetPackages.darwin.LibsystemCross for x86_64-apple-darwin`
+        (if (stdenv.isDarwin && stdenv.isAarch64) then pkgsStatic.libiconv else pkgs.libiconv)
+        pkgs.pkg-config
+      ];
+      buildInputs = lib.optionals pkgs.stdenv.isDarwin
+        (
+          with pkgs.apple_sdk_frameworks; [
+            IOKit
+            CoreFoundation
+          ]
+        ) ++ lib.optionals pkgs.stdenv.isLinux [
+        pkgsStatic.openssl
+      ];
+      DEVOUR_FLAKE = inputs.devour-flake;
+      OM_INIT_REGISTRY = rust-project.src + /crates/flakreate/registry;
+      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
+      DEFAULT_FLAKE_SCHEMAS = inputs.flake-schemas;
+      # Disable tests due to sandboxing issues; we run them on CI
+      # instead.
+      doCheck = false;
+      meta = {
+        description = "Command-line interface for Omnix";
+        mainProgram = "om";
+      };
+      CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+    } //
+    lib.optionalAttrs pkgs.stdenv.isLinux {
+      CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+    };
+  };
+}

--- a/crates/omnix-gui/crate.nix
+++ b/crates/omnix-gui/crate.nix
@@ -1,0 +1,41 @@
+{ flake
+, pkgs
+, lib
+, ...
+}:
+
+let
+  inherit (flake) inputs;
+in
+{
+  autoWire = false;
+  crane = {
+    args = {
+      buildInputs = lib.optionals pkgs.stdenv.isLinux
+        (with pkgs; [
+          webkitgtk_4_1
+          xdotool
+          pkg-config
+        ]) ++ lib.optionals pkgs.stdenv.isDarwin (
+        with pkgs.apple_sdk_frameworks; [
+          IOKit
+          Carbon
+          WebKit
+          Security
+          Cocoa
+          CoreFoundation
+        ]
+      );
+      nativeBuildInputs = with pkgs;[
+        pkg-config
+        makeWrapper
+        tailwindcss
+        dioxus-cli
+        pkgs.nix # cargo tests need nix
+      ];
+      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
+      DEFAULT_FLAKE_SCHEMAS = inputs.flake-schemas;
+      meta.description = "Graphical user interface for Omnix";
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1722280942,
-        "narHash": "sha256-xbL+LnUrWQoW6yukTSI1KN0vfnHNus+hwXP1h6NLvhU=",
+        "lastModified": 1722897042,
+        "narHash": "sha256-fwc1q5zUttPgOtDUKhkM427ABrsNGPOCOFsdo2X3BdY=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "a51532d54713d0b4a0f999da4753026af9068df2",
+        "rev": "747daa629bd956c9e14b1436b5f425ac82a01d14",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,6 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
 
-    # TODO: Use upstream after https://github.com/NixOS/nix/pull/8892
-    # Note: This version of nix is only used to run `nix flake show` in omnix-cli
-    # Also note: Using shivaraj-bh fork of nix which fixes x86_64-darwin on top of github:DeterminateSystems/nix-src/flake-schemas
-    nix.url = "github:shivaraj-bh/nix/flake-schemas";
-
     rust-flake.url = "github:juspay/rust-flake";
     rust-flake.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
@@ -25,6 +20,11 @@
 
     flake-schemas.url = "github:DeterminateSystems/flake-schemas/0a5c42297d870156d9c57d8f99e476b738dcd982";
     flake-schemas.flake = false;
+    # TODO: Use upstream after https://github.com/NixOS/nix/pull/8892
+    # Note: This version of nix is only used to run `nix flake show` in omnix-cli
+    # Also note: Using shivaraj-bh fork of nix which fixes x86_64-darwin on top of github:DeterminateSystems/nix-src/flake-schemas
+    nix.url = "github:shivaraj-bh/nix/flake-schemas";
+
   };
 
   outputs = inputs:

--- a/nix/modules/nixpkgs.nix
+++ b/nix/modules/nixpkgs.nix
@@ -5,8 +5,8 @@
   ];
   perSystem = { inputs', config, self', pkgs, lib, system, ... }: {
     nixpkgs.overlays = [
-      # Configure tailwind to enable all relevant plugins
       (self: super: {
+        # Configure tailwind to enable all relevant plugins
         tailwindcss = super.tailwindcss.overrideAttrs
           (oa: {
             plugins = [
@@ -17,6 +17,20 @@
               pkgs.nodePackages."@tailwindcss/typography"
             ];
           });
+
+        # To compile for `x86_64-darwin` we need 11.0
+        # see: https://github.com/NixOS/nixpkgs/pull/261683#issuecomment-1772935802
+        apple_sdk_frameworks =
+          if system == "x86_64-darwin"
+          then pkgs.darwin.apple_sdk_11_0.frameworks
+          else pkgs.darwin.apple_sdk.frameworks;
+
+        # Like pkgs.nix, but with flake-schemas implemented.
+        # Using until https://github.com/NixOS/nix/pull/8892 is upstreamed
+        nix-flake-schemas =
+          if pkgs.stdenv.isLinux
+          then inputs'.nix.packages.nix-static
+          else inputs'.nix.packages.default;
       })
     ];
   };


### PR DESCRIPTION
Use the new upstream `rust-flake`, consequently, using https://github.com/juspay/rust-flake/pull/21

Also, add `pkgs.nix-flake-schemas` to overlay, thus decoupling the handling nix fork to nixpkgs.nix module.