### PR TITLE
Add omnix flake-module

### DIFF
--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -102,7 +102,7 @@ impl NixHealth {
                 traits::CheckResult::Red { msg, suggestion } => {
                     res.register_failure(check.required);
                     if check.required {
-                        tracing::info!(
+                        tracing::error!(
                             "❌ {}\n    {}\n   {}\n   {}",
                             check.title.red().bold(),
                             check.info.blue(),
@@ -110,7 +110,7 @@ impl NixHealth {
                             suggestion
                         );
                     } else {
-                        tracing::info!(
+                        tracing::warn!(
                             "🟧 {}\n   {}\n   {}\n   {}",
                             check.title.yellow().bold(),
                             check.info.blue(),
@@ -189,7 +189,7 @@ impl AllChecksResult {
                 0
             }
             AllChecksResult::Fail => {
-                tracing::info!("{}", "❌ Some required checks failed".red().bold());
+                tracing::error!("{}", "❌ Some required checks failed".red().bold());
                 1
             }
         }

--- a/crates/omnix/src/logging.rs
+++ b/crates/omnix/src/logging.rs
@@ -86,10 +86,12 @@ where
         mut writer: format::Writer<'_>,
         event: &Event<'_>,
     ) -> fmt::Result {
+        /*
         let metadata = event.metadata();
         if metadata.level() != &tracing::Level::INFO {
             write!(&mut writer, "{} {}: ", metadata.level(), metadata.target())?;
         }
+        */
         ctx.field_format().format_fields(writer.by_ref(), event)?;
         writeln!(writer)
     }

--- a/doc/src/om/health.md
+++ b/doc/src/om/health.md
@@ -81,28 +81,27 @@ $ nix eval --impure --expr 'builtins.fromJSON (builtins.readFile ./schema.json)'
 }
 ```
 
-### Adding devShell check {#devShell}
+### Adding devShell check {#devshell}
 
 > [!WARNING]
-> This section needs to rewritten for omnix.
+> This section needs to finalized for omnix. See [here](https://github.com/srid/haskell-template/pull/139/files) for the up-to-date proof of concept.
 
 You can automatically run `om health` whenever your Nix dev shell starts. To do this, import the flake module in your flake and use it in your devShell:
 
 ```nix
 {
   inputs = {
-    # NOTE: refers to ./module flake.
-    nix-health.url = "github:juspay/nix-health?dir=module";
+    omnix-flake.url = "github:juspay/omnix?dir=nix/om";
   };
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
-        inputs.nix-health.flakeModule
+        inputs.omnix-flake.flakeModules.default
       ];
       perSystem = { config, pkgs, ... }: {
         devShells.default = pkgs.mkShell {
           inputsFrom = [
-            config.nix-health.outputs.devShell
+            config.om.health.outputs.devShell
           ]
         };
       };
@@ -113,7 +112,7 @@ You can automatically run `om health` whenever your Nix dev shell starts. To do 
 Now suppose you have Nix 2.18 installed, but your project requires 2.19 or above due to the following config in its `flake.nix`:
 
 ```nix
-flake.nix-health.default = {
+flake.om.health.default = {
   nix-version.min-required = "2.19.0";
 };
 ```

--- a/nix/om/flake-module.nix
+++ b/nix/om/flake-module.nix
@@ -1,0 +1,31 @@
+# The omnix flake-parts module
+{ self, lib, flake-parts-lib, ... }:
+
+let
+  inherit (flake-parts-lib)
+    mkPerSystemOption;
+in
+{
+  options = {
+    perSystem = mkPerSystemOption
+      ({ config, pkgs, ... }: {
+        options.om.health.outputs.devShell = lib.mkOption {
+          type = lib.types.package;
+          description = ''
+            Add a shellHook for running `om health` on the flake.
+          '';
+          default = pkgs.mkShell {
+            shellHook = ''
+              # Must use a subshell so that 'trap' handles only `om health`
+              # crashes.
+              (
+                trap "${lib.getExe pkgs.toilet} NIX UNHEALTHY --filter gay -f smmono9" ERR
+
+                ${lib.getExe pkgs.omnix} health --quiet .
+              )
+            '';
+          };
+        };
+      });
+  };
+}

--- a/nix/om/flake.nix
+++ b/nix/om/flake.nix
@@ -1,0 +1,8 @@
+{
+  outputs = _: {
+    flakeModules = rec {
+      default = om;
+      om = ./flake-module.nix;
+    };
+  };
+}


### PR DESCRIPTION
This provides a replacement for the `nix-health` flake-module.

Example usage: https://github.com/srid/haskell-template/pull/139