### PR TITLE
ci: Fix `--override-input` not being processed

### DIFF
--- a/crates/nixci/src/lib.rs
+++ b/crates/nixci/src/lib.rs
@@ -19,7 +19,7 @@ use nix_rs::{
 };
 use tracing::instrument;
 
-/// Run nixci on the given [CliArgs], returning the built outputs in sorted order.
+/// Run nixci on the given [Command], returning the built outputs in sorted order.
 #[instrument(name = "nixci", skip(command))]
 pub async fn nixci(
     nixcmd: &NixCmd,

--- a/crates/omnix-cli/src/command/ci.rs
+++ b/crates/omnix-cli/src/command/ci.rs
@@ -19,8 +19,10 @@ impl CICommand {
     ///
     /// If the user has not provided one, return the build command by default.
     pub fn command(&self) -> nixci::cli::Command {
-        let cfg = BuildCommand::parse_from::<[_; 0], &str>([]);
-        self.command.clone().unwrap_or(Command::Build(cfg))
+        let cmd = BuildCommand::parse_from::<[_; 0], &str>([]);
+        let mut cmd = self.command.clone().unwrap_or(Command::Build(cmd));
+        cmd.preprocess();
+        cmd
     }
 
     pub async fn run(&self, verbosity: Verbosity<InfoLevel>) -> anyhow::Result<()> {

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+
+- `om ci build`: The `--override-input` option mandated `flake/` prefix (nixci legacy) which is no longer necessary in this release.
 
 ## 0.1.0 (2024-08-08) {#0.1.0}
 


### PR DESCRIPTION
There was a regression when we migrated from `nixci` to `om ci`. This contribution got lost: https://github.com/srid/nixci/pull/74

This PR restores it for `om ci build`.