### PR TITLE
ci: Do not pass "github:nix-systems/empty"

### DIFF
--- a/crates/nixci/src/config.rs
+++ b/crates/nixci/src/config.rs
@@ -149,6 +149,7 @@ impl SubflakeConfig {
         build_cfg: &BuildCommand,
         flake_url: &FlakeUrl,
     ) -> Vec<String> {
+        let systems_flake_url = build_cfg.systems.0.clone();
         std::iter::once(flake_url.sub_flake_url(self.dir.clone()).0)
             .chain(self.override_inputs.iter().flat_map(|(k, v)| {
                 [
@@ -160,11 +161,18 @@ impl SubflakeConfig {
                     v.0.to_string(),
                 ]
             }))
-            .chain([
-                "--override-input".to_string(),
-                "systems".to_string(),
-                build_cfg.systems.0 .0.clone(),
-            ])
+            .chain(
+                if systems_flake_url.0 == "github:nix-systems/empty".to_string() {
+                    // devour-flake already uses this, so no need to override.
+                    vec![]
+                } else {
+                    vec![
+                        "--override-input".to_string(),
+                        "systems".to_string(),
+                        systems_flake_url.0,
+                    ]
+                },
+            )
             .chain(build_cfg.extra_nix_build_args.iter().cloned())
             .collect()
     }


### PR DESCRIPTION
As it is the default in devour-flake.

This may fix the CI failure on `main` due to github rate limit.  As temporary fix for #210 