### PR TITLE
Start requiring Rust docs

### DIFF
--- a/crates/nixci/crate.nix
+++ b/crates/nixci/crate.nix
@@ -27,6 +27,9 @@ in
         ) ++ lib.optionals pkgs.stdenv.isLinux [
         pkgs.openssl
       ];
+      # Disable tests due to sandboxing issues; we run them on CI
+      # instead.
+      doCheck = false;
       DEVOUR_FLAKE = inputs.devour-flake;
       NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
       DEFAULT_FLAKE_SCHEMAS = inputs.flake-schemas;

--- a/crates/nixci/crate.nix
+++ b/crates/nixci/crate.nix
@@ -8,6 +8,7 @@ let
   inherit (flake) inputs;
 in
 {
+  autoWire = true;
   crane = {
     args = {
       nativeBuildInputs = with pkgs; with pkgs.apple_sdk_frameworks; lib.optionals stdenv.isDarwin [
@@ -27,6 +28,8 @@ in
         pkgs.openssl
       ];
       DEVOUR_FLAKE = inputs.devour-flake;
+      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
+      DEFAULT_FLAKE_SCHEMAS = inputs.flake-schemas;
     };
   };
 }

--- a/crates/nixci/src/command/core.rs
+++ b/crates/nixci/src/command/core.rs
@@ -36,7 +36,7 @@ impl Command {
     /// Run the command
     #[instrument(name = "run", skip(self))]
     pub async fn run(self, nixcmd: &NixCmd, verbose: bool) -> anyhow::Result<()> {
-        tracing::info!("{}", format!("\n👟 Reading om.ci config from flake").bold());
+        tracing::info!("{}", "\n👟 Reading om.ci config from flake".bold());
         let cfg = self.get_config(nixcmd).await?;
         match self {
             Command::Run(cmd) => cmd.run(nixcmd, verbose, cfg).await,

--- a/crates/nixci/src/command/core.rs
+++ b/crates/nixci/src/command/core.rs
@@ -1,3 +1,4 @@
+//! The nixci commands
 use clap::Subcommand;
 use colored::Colorize;
 use nix_rs::command::NixCmd;
@@ -7,10 +8,13 @@ use crate::{config::core::Config, flake_ref::FlakeRef};
 
 use super::{gh_matrix::GHMatrixCommand, run::RunCommand};
 
+/// Top-level commands for `om ci`
 #[derive(Debug, Subcommand, Clone)]
 pub enum Command {
+    /// Run all CI steps for all or given subflakes
     Run(RunCommand),
 
+    /// Print the Github Actions matrix configuration as JSON
     #[clap(name = "gh-matrix")]
     DumpGithubActionsMatrix(GHMatrixCommand),
 }
@@ -22,13 +26,14 @@ impl Default for Command {
 }
 
 impl Command {
-    // Pre-process `Command`
+    /// Pre-process `Command`
     pub fn preprocess(&mut self) {
         if let Command::Run(cmd) = self {
             cmd.preprocess()
         }
     }
 
+    /// Run the command
     #[instrument(name = "run", skip(self))]
     pub async fn run(self, nixcmd: &NixCmd, verbose: bool) -> anyhow::Result<()> {
         tracing::info!("{}", format!("\n👟 Reading om.ci config from flake").bold());

--- a/crates/nixci/src/command/gh_matrix.rs
+++ b/crates/nixci/src/command/gh_matrix.rs
@@ -1,9 +1,10 @@
+//! The gh-matrix command
 use clap::Parser;
 use nix_rs::flake::system::System;
 
 use crate::{config::core::Config, flake_ref::FlakeRef, github};
 
-/// Print the Github Actions matrix configuration as JSON
+/// Command to generate a Github Actions matrix
 #[derive(Parser, Debug, Clone)]
 pub struct GHMatrixCommand {
     /// Flake URL or github URL
@@ -19,6 +20,7 @@ pub struct GHMatrixCommand {
 }
 
 impl GHMatrixCommand {
+    /// Run the command
     pub async fn run(&self, cfg: Config) -> anyhow::Result<()> {
         let matrix = github::matrix::GitHubMatrix::from(self.systems.clone(), &cfg.subflakes);
         println!("{}", serde_json::to_string(&matrix)?);

--- a/crates/nixci/src/command/run.rs
+++ b/crates/nixci/src/command/run.rs
@@ -1,3 +1,4 @@
+//! The run command
 use anyhow::{Context, Result};
 use clap::Parser;
 use colored::Colorize;
@@ -15,7 +16,7 @@ use crate::{
     nix::system_list::{SystemsList, SystemsListFlakeRef},
 };
 
-/// Run all CI steps for all or given subflakes
+/// Command to run all CI steps
 #[derive(Parser, Debug, Clone)]
 pub struct RunCommand {
     /// The systems list to build for. If empty, build for current system.
@@ -33,6 +34,7 @@ pub struct RunCommand {
     #[arg(default_value = ".")]
     pub flake_ref: FlakeRef,
 
+    /// Arguments for all steps
     #[command(flatten)]
     pub steps_args: crate::step::core::StepsArgs,
 }
@@ -44,6 +46,7 @@ impl Default for RunCommand {
 }
 
 impl RunCommand {
+    /// Preprocess this command
     pub fn preprocess(&mut self) {
         self.steps_args.build_step_args.preprocess();
     }
@@ -98,7 +101,7 @@ pub async fn check_nix_version(flake_url: &FlakeUrl, nix_info: &NixInfo) -> anyh
     Ok(())
 }
 
-// Run CI fo all subflakes
+/// Run CI fo all subflakes
 pub async fn ci_run(
     cmd: &NixCmd,
     verbose: bool,

--- a/crates/nixci/src/command/run.rs
+++ b/crates/nixci/src/command/run.rs
@@ -56,22 +56,22 @@ impl RunCommand {
         // TODO: We'll refactor this function to use steps
         // https://github.com/juspay/omnix/issues/216
 
-        tracing::info!("{}", format!("\n👟 Gathering NixInfo").bold());
+        tracing::info!("{}", "\n👟 Gathering NixInfo".bold());
         let nix_info = NixInfo::get()
             .await
             .as_ref()
             .with_context(|| "Unable to gather nix info")?;
 
         // First, run the necessary health checks
-        tracing::info!("{}", format!("\n🫀 Performing health check").bold());
-        check_nix_version(&cfg.ref_.flake_url, &nix_info).await?;
+        tracing::info!("{}", "\n🫀 Performing health check".bold());
+        check_nix_version(&cfg.ref_.flake_url, nix_info).await?;
 
         // Then, do the CI steps
         tracing::info!(
             "{}",
             format!("\n🤖 Running CI for {}", self.flake_ref).bold()
         );
-        ci_run(nixcmd, verbose, &self, &cfg, &nix_info.nix_config).await?;
+        ci_run(nixcmd, verbose, self, &cfg, &nix_info.nix_config).await?;
 
         Ok(())
     }

--- a/crates/nixci/src/config/core.rs
+++ b/crates/nixci/src/config/core.rs
@@ -1,3 +1,4 @@
+//! The top-level configuration of nixci, as defined in flake.nix
 use anyhow::Result;
 use nix_rs::{
     command::NixCmd,

--- a/crates/nixci/src/config/ref_.rs
+++ b/crates/nixci/src/config/ref_.rs
@@ -1,3 +1,4 @@
+//! A reference to a nixci configuration
 use nix_rs::flake::url::FlakeUrl;
 
 /// A reference into one or all [crate::config::subflakes::SubflakesConfig] of some [FlakeUrl]

--- a/crates/nixci/src/config/subflake.rs
+++ b/crates/nixci/src/config/subflake.rs
@@ -1,3 +1,4 @@
+//! Subflake configuration
 use std::collections::BTreeMap;
 
 use nix_rs::flake::{system::System, url::FlakeUrl};
@@ -46,6 +47,7 @@ impl Default for SubflakeConfig {
 }
 
 impl SubflakeConfig {
+    /// Whether this subflake can be built on any of the given systems
     pub fn can_build_on(&self, systems: &[System]) -> bool {
         match self.systems.as_ref() {
             Some(systems_whitelist) => systems_whitelist.iter().any(|s| systems.contains(s)),

--- a/crates/nixci/src/config/subflakes.rs
+++ b/crates/nixci/src/config/subflakes.rs
@@ -1,9 +1,11 @@
+//! Subflakes configuration group.
 use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
 use super::subflake::SubflakeConfig;
 
+/// CI configuration for a subflake
 #[derive(Debug, Deserialize)]
 pub struct SubflakesConfig(
     // NB: we use BTreeMap instead of HashMap here so that we always iterate

--- a/crates/nixci/src/github/matrix.rs
+++ b/crates/nixci/src/github/matrix.rs
@@ -7,13 +7,16 @@ use crate::config::subflakes::SubflakesConfig;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// A row in the Github Actions matrix configuration
 pub struct GitHubMatrixRow {
+    /// System to build on
     pub system: System,
+    /// Subflake to build
     pub subflake: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Github Actions matrix configuration
 pub struct GitHubMatrix {
+    /// The includes
     pub include: Vec<GitHubMatrixRow>,
 }
 

--- a/crates/nixci/src/github/pull_request.rs
+++ b/crates/nixci/src/github/pull_request.rs
@@ -56,7 +56,9 @@ impl PullRequestRef {
 /// Github Pull Request API Response
 #[derive(Debug, Deserialize)]
 pub struct PullRequest {
+    /// PR URL
     pub url: String,
+    /// [Head] info
     pub head: Head,
 }
 
@@ -64,7 +66,9 @@ pub struct PullRequest {
 #[derive(Debug, Deserialize)]
 pub struct Head {
     #[serde(rename = "ref")]
+    /// Head ref
     pub ref_: String,
+    /// Head [Repo]
     pub repo: Repo,
 }
 

--- a/crates/nixci/src/lib.rs
+++ b/crates/nixci/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 pub mod command;
 pub mod config;
 pub mod flake_ref;

--- a/crates/nixci/src/lib.rs
+++ b/crates/nixci/src/lib.rs
@@ -1,3 +1,4 @@
+//! nixci: CI for Nix projects
 #![warn(missing_docs)]
 pub mod command;
 pub mod config;

--- a/crates/nixci/src/nix/devour_flake.rs
+++ b/crates/nixci/src/nix/devour_flake.rs
@@ -10,6 +10,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 /// We expect this environment to be set in Nix build and shell.
 pub const DEVOUR_FLAKE: &str = env!("DEVOUR_FLAKE");
 
+/// Output of `devour-flake` command
 pub struct DevourFlakeOutput(pub HashSet<StorePath>);
 
 impl FromStr for DevourFlakeOutput {
@@ -31,6 +32,7 @@ impl FromStr for DevourFlakeOutput {
     }
 }
 
+/// Run `devour-flake` command
 pub async fn devour_flake(
     nixcmd: &NixCmd,
     verbose: bool,

--- a/crates/nixci/src/nix/lock.rs
+++ b/crates/nixci/src/nix/lock.rs
@@ -1,3 +1,4 @@
+//! Functions for working with `nix flake lock`.
 use std::process::Stdio;
 
 use anyhow::{bail, Result};

--- a/crates/nixci/src/nix/system_list.rs
+++ b/crates/nixci/src/nix/system_list.rs
@@ -1,3 +1,4 @@
+//! Dealing with system lists
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -29,9 +30,11 @@ impl FromStr for SystemsListFlakeRef {
     }
 }
 
+/// A list of [System]s
 pub struct SystemsList(pub Vec<System>);
 
 impl SystemsList {
+    /// Load the list of systems defined in a flake
     pub async fn from_flake(cmd: &NixCmd, url: &SystemsListFlakeRef) -> Result<Self> {
         // Nix eval, and then return the systems
         match SystemsList::from_known_flake(url) {
@@ -67,6 +70,7 @@ impl SystemsList {
     }
 }
 
+/// Evaluate `import <flake-url>` and return the result JSON parsed.
 pub async fn nix_import_flake<T>(cmd: &NixCmd, url: &FlakeUrl) -> Result<T, NixCmdError>
 where
     T: Default + serde::de::DeserializeOwned,

--- a/crates/nixci/src/step/build.rs
+++ b/crates/nixci/src/step/build.rs
@@ -1,3 +1,4 @@
+//! The build step
 use clap::Parser;
 use colored::Colorize;
 use nix_rs::{command::NixCmd, flake::url::FlakeUrl, store::NixStoreCmd};
@@ -14,6 +15,7 @@ use crate::{
 /// It builds all flake outputs.
 #[derive(Debug, Deserialize)]
 pub struct BuildStep {
+    /// Whether to enable this step
     pub enable: bool,
 }
 
@@ -23,6 +25,7 @@ impl Default for BuildStep {
     }
 }
 
+/// CLI arguments for [BuildStep]
 #[derive(Parser, Debug, Clone)]
 pub struct BuildStepArgs {
     /// Additional arguments to pass through to `nix build`
@@ -42,6 +45,7 @@ pub struct BuildStepArgs {
 }
 
 impl BuildStepArgs {
+    /// Preprocess the arguments
     pub fn preprocess(&mut self) {
         // Adjust to devour_flake's expectations
         devour_flake::transform_override_inputs(&mut self.extra_nix_build_args);
@@ -49,6 +53,7 @@ impl BuildStepArgs {
 }
 
 impl BuildStep {
+    /// Run this step
     pub async fn run(
         &self,
         nixcmd: &NixCmd,

--- a/crates/nixci/src/step/core.rs
+++ b/crates/nixci/src/step/core.rs
@@ -1,3 +1,4 @@
+//! All CI steps available in nixci
 use clap::Parser;
 use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 use serde::Deserialize;
@@ -14,18 +15,23 @@ use crate::step::{
 /// Contains some builtin steps, as well as custom steps (defined by user)
 #[derive(Debug, Default, Deserialize)]
 pub struct Steps {
+    /// [LockfileStep]
     pub lockfile_step: LockfileStep,
+    /// [BuildStep]
     pub build_step: BuildStep,
     // TODO: custom steps
 }
 
+/// CLI arguments associated with [Steps]
 #[derive(Parser, Debug, Clone)]
 pub struct StepsArgs {
+    /// [BuildStepArgs]
     #[command(flatten)]
     pub build_step_args: BuildStepArgs,
 }
 
 impl Steps {
+    /// Run all CI steps
     pub async fn run(
         &self,
         cmd: &NixCmd,

--- a/crates/nixci/src/step/lockfile.rs
+++ b/crates/nixci/src/step/lockfile.rs
@@ -1,3 +1,4 @@
+//! The lockfile step
 use colored::Colorize;
 use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 use serde::Deserialize;
@@ -7,6 +8,7 @@ use crate::{config::subflake::SubflakeConfig, nix};
 /// Check that `flake.lock` is not out of date.
 #[derive(Debug, Deserialize)]
 pub struct LockfileStep {
+    /// Whether to enable this step
     pub enable: bool,
 }
 
@@ -17,6 +19,7 @@ impl Default for LockfileStep {
 }
 
 impl LockfileStep {
+    /// Run this step
     pub async fn run(
         &self,
         nixcmd: &NixCmd,

--- a/crates/nixci/src/step/lockfile.rs
+++ b/crates/nixci/src/step/lockfile.rs
@@ -27,10 +27,7 @@ impl LockfileStep {
         subflake: &SubflakeConfig,
     ) -> anyhow::Result<()> {
         if subflake.override_inputs.is_empty() {
-            tracing::info!(
-                "{}",
-                format!("🫀 Checking that flake.lock is up-to-date").bold()
-            );
+            tracing::info!("{}", "🫀 Checking that flake.lock is up-to-date".bold());
             let sub_flake_url = url.sub_flake_url(subflake.dir.clone());
             nix::lock::nix_flake_lock_check(nixcmd, &sub_flake_url).await?;
         }

--- a/crates/omnix-cli/crate.nix
+++ b/crates/omnix-cli/crate.nix
@@ -34,12 +34,12 @@ in
         ) ++ lib.optionals pkgs.stdenv.isLinux [
         pkgsStatic.openssl
       ];
-      DEVOUR_FLAKE = inputs.devour-flake;
       OM_INIT_REGISTRY =
         lib.cleanSourceWith {
           name = "flakreate-registry";
           src = flake.inputs.self + /crates/flakreate/registry;
         };
+      DEVOUR_FLAKE = inputs.devour-flake;
       NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
       DEFAULT_FLAKE_SCHEMAS = inputs.flake-schemas;
       # Disable tests due to sandboxing issues; we run them on CI


### PR DESCRIPTION
Let's require docs for all public modules, functions and types.

This is to help keep the code simple. 

>  If your code needs a novel to explain, it's not simple. A few well-placed comments or doc strings can turn cryptic code into a clear narrative.