### PR TITLE
refactor: Initial decoupling of devour-flake interface

### DIFF
--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **`flake::url`**
   - Add `without_attr`, `get_attr`
   - Simplify the return type of `RootQualifiedAttr::eval_flake`
+  - Add `AsRef` and `Deref` instances for `FlakeUrl`
 - **`store`**: Add module (upstreamed from nixci)
 - **`env`**:
   - `NixEnv::detect`'s logging uses DEBUG level now (formerly INFO)

--- a/crates/nix_rs/src/flake/outputs.rs
+++ b/crates/nix_rs/src/flake/outputs.rs
@@ -223,7 +223,7 @@ impl FlakeOutputsUntagged {
                 "--json",
                 "--default-flake-schemas",
                 env!("DEFAULT_FLAKE_SCHEMAS"),
-                &flake_url.to_string(),
+                flake_url,
             ])
             .await?;
         Ok(v)

--- a/crates/nix_rs/src/flake/url/core.rs
+++ b/crates/nix_rs/src/flake/url/core.rs
@@ -3,6 +3,7 @@
 //! See <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#url-like-syntax>
 use std::{
     fmt::{Display, Formatter},
+    ops::Deref,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -19,6 +20,20 @@ use super::attr::FlakeAttr;
 /// you know the URL is valid.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct FlakeUrl(pub String);
+
+impl AsRef<str> for FlakeUrl {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for FlakeUrl {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl FlakeUrl {
     /// Provide real-world examples of flake URLs

--- a/crates/nixci/src/nix/devour_flake.rs
+++ b/crates/nixci/src/nix/devour_flake.rs
@@ -2,29 +2,24 @@
 
 use anyhow::{bail, Context, Result};
 use nix_rs::{command::NixCmd, store::StorePath};
-use std::{collections::HashSet, path::PathBuf, process::Stdio, str::FromStr};
+use std::{collections::HashSet, path::PathBuf, process::Stdio};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-/// Absolute path to the devour-flake executable
-///
-/// We expect this environment to be set in Nix build and shell.
+/// Absolute path to the devour-flake flake source
 pub const DEVOUR_FLAKE: &str = env!("DEVOUR_FLAKE");
 
-/// Output of `devour-flake` command
+/// Output of `devour-flake`
 pub struct DevourFlakeOutput(pub HashSet<StorePath>);
 
-impl FromStr for DevourFlakeOutput {
-    type Err = anyhow::Error;
-
-    fn from_str(output_filename: &str) -> Result<Self, Self::Err> {
-        // Read output_filename, as newline separated strings
-        let raw_output = std::fs::read_to_string(output_filename)?;
+impl DevourFlakeOutput {
+    fn from_drv(drv_out: &str) -> anyhow::Result<Self> {
+        let raw_output = std::fs::read_to_string(drv_out)?;
         let outs = raw_output.split_ascii_whitespace();
         let outs: HashSet<StorePath> = outs.map(|s| StorePath::new(PathBuf::from(s))).collect();
         if outs.is_empty() {
             bail!(
                 "devour-flake produced an outpath ({}) with no outputs",
-                output_filename
+                drv_out
             );
         } else {
             Ok(DevourFlakeOutput(outs))
@@ -75,8 +70,8 @@ pub async fn devour_flake(
         .await
         .context("Unable to spawn devour-flake process")?;
     if output.status.success() {
-        let stdout = String::from_utf8(output.stdout)?;
-        let v = DevourFlakeOutput::from_str(stdout.trim())?;
+        let drv_out = String::from_utf8(output.stdout)?;
+        let v = DevourFlakeOutput::from_drv(drv_out.trim())?;
         Ok(v)
     } else {
         let exit_code = output.status.code().unwrap_or(1);

--- a/crates/nixci/src/step/build.rs
+++ b/crates/nixci/src/step/build.rs
@@ -7,7 +7,10 @@ use serde::Deserialize;
 use crate::{
     command::run::RunCommand,
     config::subflake::SubflakeConfig,
-    nix::{self, devour_flake},
+    nix::{
+        self,
+        devour_flake::{self, DevourFlakeInput},
+    },
 };
 
 /// Represents a build step in the CI pipeline
@@ -67,8 +70,13 @@ impl BuildStep {
             "{}",
             format!("⚒️  Building subflake: {}", subflake.dir).bold()
         );
-        let nix_args = nix_build_args_for_subflake(subflake, run_cmd, url);
-        let output = nix::devour_flake::devour_flake(nixcmd, verbose, nix_args).await?;
+        let nix_args = subflake_extra_args(subflake, &run_cmd.steps_args.build_step_args);
+        let devour_input = DevourFlakeInput {
+            flake: url.sub_flake_url(subflake.dir.clone()),
+            systems: run_cmd.systems.0.clone(),
+        };
+        let output =
+            nix::devour_flake::devour_flake(nixcmd, verbose, devour_input, nix_args).await?;
 
         let outs = if run_cmd.steps_args.build_step_args.print_all_dependencies {
             // Handle --print-all-dependencies
@@ -84,14 +92,9 @@ impl BuildStep {
     }
 }
 
-/// Return the devour-flake `nix build` arguments for building all the outputs in this
-/// subflake configuration.
-fn nix_build_args_for_subflake(
-    subflake: &SubflakeConfig,
-    run_cmd: &RunCommand,
-    flake_url: &FlakeUrl,
-) -> Vec<String> {
-    let mut args = vec![flake_url.sub_flake_url(subflake.dir.clone()).0];
+/// Extra args to pass to devour-flake
+fn subflake_extra_args(subflake: &SubflakeConfig, build_step_args: &BuildStepArgs) -> Vec<String> {
+    let mut args = vec![];
 
     for (k, v) in &subflake.override_inputs {
         args.extend_from_slice(&[
@@ -101,23 +104,7 @@ fn nix_build_args_for_subflake(
         ])
     }
 
-    // devour-flake already uses this, so no need to override.
-    if run_cmd.systems.0 .0 != "github:nix-systems/empty" {
-        args.extend_from_slice(&[
-            "--override-input".to_string(),
-            "systems".to_string(),
-            run_cmd.systems.0 .0.clone(),
-        ])
-    }
-
-    args.extend(
-        run_cmd
-            .steps_args
-            .build_step_args
-            .extra_nix_build_args
-            .iter()
-            .cloned(),
-    );
+    args.extend(build_step_args.extra_nix_build_args.iter().cloned());
 
     args
 }


### PR DESCRIPTION
Turns out that https://github.com/srid/devour-flake is just a specific example of a more general idea wherein we define a cross-language function: the function body defined in Nix (as derivation), with flake inputs being "arguments" to it, and the outPath of that derivation as the "return" of the function.

In devour-flake, the input arguments are "flake" (flake to be built) and "systems". We can represent this in Rust as:

```rust
pub struct DevourFlakeInput {
    /// The flake devour-flake will build
    pub flake: FlakeUrl,
    /// The systems it will build for. An empty list means all allowed systems.
    pub systems: FlakeUrl,
}
```

Likewise, the return of the function is a file containing all built paths, which in Rust is:

```rust
pub struct DevourFlakeOutput(pub HashSet<StorePath>);
```

This PR prepares the ground of creating this more generation mechanism, where the entirety of nixci's `devour_flake.rs` can be generalized so that it can be used for any such function (for example, #51). The result is also simpler to reason about code.