### PR TITLE
ci: Avoid redundant nix-store invocations when `--print-all-dependencies`

### DIFF
--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **`store`**:
   - Add module (upstreamed from nixci)
   - Add `StoreURI`
+  - Avoid running `nix-store` multiple times.
 - **`env`**:
   - `NixEnv::detect`'s logging uses DEBUG level now (formerly INFO)
   - Add Nix installer to `NixEnv`

--- a/crates/nix_rs/src/store.rs
+++ b/crates/nix_rs/src/store.rs
@@ -111,13 +111,8 @@ impl NixStoreCmd {
         drv_paths: &[PathBuf],
     ) -> Result<HashSet<StorePath>, NixStoreCmdError> {
         let mut cmd = self.command();
-        let mut args = vec!["--query", "--requisites", "--include-outputs"];
-        let paths: Vec<&str> = drv_paths
-            .iter()
-            .map(|path| path.as_path().to_str().unwrap_or_default())
-            .collect();
-        args.extend(paths);
-        cmd.args(args);
+        cmd.args(["--query", "--requisites", "--include-outputs"])
+            .args(drv_paths);
         crate::command::trace_cmd(&cmd);
         let out = cmd.output().await?;
         if out.status.success() {

--- a/crates/nix_rs/src/store.rs
+++ b/crates/nix_rs/src/store.rs
@@ -71,7 +71,7 @@ impl NixStoreCmd {
             all_drvs.insert(drv);
         }
         let all_outs = self
-            .nix_store_query_requisites_with_outputs(all_drvs)
+            .nix_store_query_requisites_with_outputs(&all_drvs.iter().cloned().collect::<Vec<_>>())
             .await?;
         Ok(all_outs)
     }
@@ -108,7 +108,7 @@ impl NixStoreCmd {
     /// of its dependencies in the Nix store.
     pub async fn nix_store_query_requisites_with_outputs(
         &self,
-        drv_paths: HashSet<PathBuf>,
+        drv_paths: &[PathBuf],
     ) -> Result<HashSet<StorePath>, NixStoreCmdError> {
         let mut cmd = self.command();
         let mut args = vec!["--query", "--requisites", "--include-outputs"];

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -8,6 +8,7 @@
   - Display Nix installer used (supports DetSys installer)
 - `om ci`
   - Support for remote builds over SSH (via `--on` option)
+  - Avoid running `nix-store` command multiple times (#224)
 
 ### Fixes
 


### PR DESCRIPTION
Resolves #220 