### PR TITLE
`om ci run --on`: Recognize and pass `--systems`

### DIFF
--- a/crates/nixci/src/command/core.rs
+++ b/crates/nixci/src/command/core.rs
@@ -59,4 +59,18 @@ impl Command {
             Command::DumpGithubActionsMatrix(cmd) => cmd.flake_ref.clone(),
         }
     }
+
+    /// Convert this type back to the user-facing command line arguments
+    pub fn to_cli_args(&self) -> Vec<String> {
+        let mut args = vec!["ci".to_string(), "run".to_string()];
+        match self {
+            Command::Run(cmd) => {
+                args.extend(cmd.to_cli_args());
+            }
+            Command::DumpGithubActionsMatrix(_cmd) => {
+                unimplemented!("Command::DumpGithubActionsMatrix::to_cli_args")
+            }
+        }
+        args
+    }
 }

--- a/crates/nixci/src/nix/devour_flake.rs
+++ b/crates/nixci/src/nix/devour_flake.rs
@@ -15,7 +15,7 @@ pub struct DevourFlakeInput {
     /// The flake devour-flake will build
     pub flake: FlakeUrl,
     /// The systems it will build for. An empty list means all allowed systems.
-    pub systems: FlakeUrl,
+    pub systems: Option<FlakeUrl>,
 }
 
 /// Output of `devour-flake`
@@ -60,8 +60,8 @@ pub async fn devour_flake(
         &input.flake,
     ];
     // Specify only if the systems is not the default
-    if input.systems.0 != "github:nix-systems/empty" {
-        args.extend_from_slice(&["--override-input", "systems", &input.systems]);
+    if let Some(systems) = input.systems.as_ref() {
+        args.extend(&["--override-input", "systems", &systems.0]);
     }
     args.extend(extra_args.iter().map(|s| s.as_str()));
     cmd.args(args);

--- a/crates/nixci/src/step/build.rs
+++ b/crates/nixci/src/step/build.rs
@@ -81,7 +81,7 @@ impl BuildStep {
         let nix_args = subflake_extra_args(subflake, &run_cmd.steps_args.build_step_args);
         let devour_input = DevourFlakeInput {
             flake: url.sub_flake_url(subflake.dir.clone()),
-            systems: run_cmd.systems.0.clone(),
+            systems: run_cmd.systems.clone().map(|l| l.0),
         };
         let output =
             nix::devour_flake::devour_flake(nixcmd, verbose, devour_input, nix_args).await?;

--- a/crates/nixci/src/step/build.rs
+++ b/crates/nixci/src/step/build.rs
@@ -35,14 +35,6 @@ impl Default for BuildStep {
 /// CLI arguments for [BuildStep]
 #[derive(Parser, Debug, Clone)]
 pub struct BuildStepArgs {
-    /// Additional arguments to pass through to `nix build`
-    #[arg(last = true, default_values_t = vec![
-    "--refresh".to_string(),
-    "-j".to_string(),
-    "auto".to_string(),
-    ])]
-    pub extra_nix_build_args: Vec<String>,
-
     /// Print build and runtime dependencies along with out paths
     ///
     /// By default, `nixci build` prints only the out paths. This option is
@@ -53,6 +45,14 @@ pub struct BuildStepArgs {
     /// Run `om ci run` remotely on the given store URI
     #[clap(long)]
     pub on: Option<StoreURI>,
+
+    /// Additional arguments to pass through to `nix build`
+    #[arg(last = true, default_values_t = vec![
+    "--refresh".to_string(),
+    "-j".to_string(),
+    "auto".to_string(),
+    ])]
+    pub extra_nix_build_args: Vec<String>,
 }
 
 impl BuildStepArgs {
@@ -60,6 +60,29 @@ impl BuildStepArgs {
     pub fn preprocess(&mut self) {
         // Adjust to devour_flake's expectations
         devour_flake::transform_override_inputs(&mut self.extra_nix_build_args);
+    }
+
+    /// Convert this type back to the user-facing command line arguments
+    pub fn to_cli_args(&self) -> Vec<String> {
+        let mut args = vec![];
+
+        if self.print_all_dependencies {
+            args.push("--print-all-dependencies".to_owned());
+        }
+
+        if let Some(uri) = self.on.as_ref() {
+            args.push("--on".to_owned());
+            args.push(uri.to_string());
+        }
+
+        if !self.extra_nix_build_args.is_empty() {
+            args.push("--".to_owned());
+            for arg in &self.extra_nix_build_args {
+                args.push(arg.clone());
+            }
+        }
+
+        args
     }
 }
 

--- a/crates/nixci/src/step/core.rs
+++ b/crates/nixci/src/step/core.rs
@@ -50,3 +50,10 @@ impl Steps {
         Ok(())
     }
 }
+
+impl StepsArgs {
+    /// Convert this type back to the user-facing command line arguments
+    pub fn to_cli_args(&self) -> Vec<String> {
+        self.build_step_args.to_cli_args()
+    }
+}


### PR DESCRIPTION
Fix #212 to support `--systems`