### PR TITLE
`om ci`: Run `nix flake check` after build

### DIFF
--- a/crates/nixci/CHANGELOG.md
+++ b/crates/nixci/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - New
   - Introduced notion of 'steps'. Renamed 'build' to 'run'.
+    - Added a step to run `nix flake check`
 - `config.rs`: Refactored to change API.
 
 ## 1.1.0

--- a/crates/nixci/src/step/build.rs
+++ b/crates/nixci/src/step/build.rs
@@ -115,7 +115,7 @@ fn subflake_extra_args(subflake: &SubflakeConfig, build_step_args: &BuildStepArg
     let mut args = vec![];
 
     for (k, v) in &subflake.override_inputs {
-        args.extend_from_slice(&[
+        args.extend([
             "--override-input".to_string(),
             format!("flake/{}", k),
             v.0.to_string(),

--- a/crates/nixci/src/step/core.rs
+++ b/crates/nixci/src/step/core.rs
@@ -3,12 +3,13 @@ use clap::Parser;
 use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 use serde::Deserialize;
 
-use crate::command::run::RunCommand;
-use crate::config::subflake::SubflakeConfig;
-use crate::step::{
+use super::{
     build::{BuildStep, BuildStepArgs},
+    flake_check::FlakeCheckStep,
     lockfile::LockfileStep,
 };
+use crate::command::run::RunCommand;
+use crate::config::subflake::SubflakeConfig;
 
 /// CI steps to run
 ///
@@ -22,6 +23,10 @@ pub struct Steps {
     /// [BuildStep]
     #[serde(default, rename = "build")]
     pub build_step: BuildStep,
+
+    /// [FlakeCheckStep]
+    #[serde(default, rename = "flake-check")]
+    pub flake_check_step: FlakeCheckStep,
     // TODO: custom steps
 }
 
@@ -47,6 +52,7 @@ impl Steps {
         self.build_step
             .run(cmd, verbose, run_cmd, url, subflake)
             .await?;
+        self.flake_check_step.run(cmd, url, subflake).await?;
         Ok(())
     }
 }

--- a/crates/nixci/src/step/flake_check.rs
+++ b/crates/nixci/src/step/flake_check.rs
@@ -1,0 +1,39 @@
+//! The cachix step
+use colored::Colorize;
+use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
+use serde::Deserialize;
+
+use crate::config::subflake::SubflakeConfig;
+
+/// Run `nix flake check`
+#[derive(Debug, Deserialize)]
+pub struct FlakeCheckStep {
+    /// Whether to enable this step
+    pub enable: bool,
+}
+
+impl Default for FlakeCheckStep {
+    fn default() -> Self {
+        FlakeCheckStep { enable: true }
+    }
+}
+
+impl FlakeCheckStep {
+    /// Run this step
+    pub async fn run(
+        &self,
+        nixcmd: &NixCmd,
+        url: &FlakeUrl,
+        subflake: &SubflakeConfig,
+    ) -> anyhow::Result<()> {
+        tracing::info!(
+            "{}",
+            format!("🩺 Running flake check on: {}", subflake.dir).bold()
+        );
+        let sub_flake_url = url.sub_flake_url(subflake.dir.clone());
+        nixcmd
+            .run_with_args(["flake", "check", &sub_flake_url])
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/nixci/src/step/flake_check.rs
+++ b/crates/nixci/src/step/flake_check.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 use crate::config::subflake::SubflakeConfig;
 
 /// Run `nix flake check`
+///
+/// Note: `nix build ...` does not evaluate all the checks that `nix flake check` does. So, enabling this steps allows `om ci` to run those evaluation checks.
 #[derive(Debug, Deserialize)]
 pub struct FlakeCheckStep {
     /// Whether to enable this step

--- a/crates/nixci/src/step/flake_check.rs
+++ b/crates/nixci/src/step/flake_check.rs
@@ -31,15 +31,9 @@ impl FlakeCheckStep {
             format!("🩺 Running flake check on: {}", subflake.dir).bold()
         );
         let sub_flake_url = url.sub_flake_url(subflake.dir.clone());
-        let mut args: Vec<String> = vec![
-            "flake".to_owned(),
-            "check".to_owned(),
-            sub_flake_url.to_string(),
-        ];
-        for (name, url) in &subflake.override_inputs {
-            args.push("--override-input".to_owned());
-            args.push(name.to_owned());
-            args.push(url.to_string());
+        let mut args = vec!["flake", "check", &sub_flake_url];
+        for (k, v) in &subflake.override_inputs {
+            args.extend(["--override-input", k, v]);
         }
         nixcmd.run_with_args(args).await?;
         Ok(())

--- a/crates/nixci/src/step/flake_check.rs
+++ b/crates/nixci/src/step/flake_check.rs
@@ -31,9 +31,17 @@ impl FlakeCheckStep {
             format!("🩺 Running flake check on: {}", subflake.dir).bold()
         );
         let sub_flake_url = url.sub_flake_url(subflake.dir.clone());
-        nixcmd
-            .run_with_args(["flake", "check", &sub_flake_url])
-            .await?;
+        let mut args: Vec<String> = vec![
+            "flake".to_owned(),
+            "check".to_owned(),
+            sub_flake_url.to_string(),
+        ];
+        for (name, url) in &subflake.override_inputs {
+            args.push("--override-input".to_owned());
+            args.push(name.to_owned());
+            args.push(url.to_string());
+        }
+        nixcmd.run_with_args(args).await?;
         Ok(())
     }
 }

--- a/crates/nixci/src/step/mod.rs
+++ b/crates/nixci/src/step/mod.rs
@@ -1,4 +1,5 @@
 //! CI is broken down into various 'steps'.
 pub mod build;
 pub mod core;
+pub mod flake_check;
 pub mod lockfile;

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -9,6 +9,7 @@
 - `om ci`
   - Support for remote builds over SSH (via `--on` option)
   - Avoid running `nix-store` command multiple times (#224)
+  - Run `nix flake check` on all subflakes (#200)
 
 ### Fixes
 


### PR DESCRIPTION
Add a new CI step (cf. #216) to `nixci` so that `nix flake check` is run for all sub-flakes as part of `om ci run`.

Resolves #200 

<img width="823" alt="image" src="https://github.com/user-attachments/assets/5e3eb8c6-84de-4d69-9f6d-553e8656cda6">
