### PR TITLE
`om ci`: Add custom steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,48 +17,34 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/cachix-action@v14
-        if: github.ref == 'refs/heads/main'
-        with:
-          name: om
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          skipPush: true
-      - name: Build
+
+      # Prep systems list
+      # Workaround until https://github.com/juspay/omnix/issues/210
+      - name: Systems to build
         run: |
-          # Prep systems list
-          # https://github.com/srid/nixci/issues/83
           mkdir ~/systems
           echo '{ outputs = _: {}; }' > ~/systems/flake.nix
           echo '[ "${{ matrix.system }}" ]' > ~/systems/default.nix
 
-          # Build all flake outputs
-          nixci \
+      # Run CI
+      - name: Omnix CI
+        run: |
+          om ci \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
-            build --systems "path:$HOME/systems"
-      - name: Check static binary size
-        if: matrix.system == 'x86_64-linux'
-        run: nix run .#check-closure-size
-      - name: nix build
+            run --systems "path:$HOME/systems"
+
+      # Upload static binary for the next job.
+      - name: "static-binary: Build"
         if: matrix.system != 'x86_64-darwin'
         run: echo "om_static_binary_path=$(nix build --no-link --print-out-paths)" >> "$GITHUB_ENV"
-      - name: Upload om static binary
+      - name: "static-binary: Upload"
         if: matrix.system != 'x86_64-darwin'
         uses: actions/upload-artifact@v4
         with:
           name: om-${{ matrix.system }}
           path: ${{ env.om_static_binary_path }}/bin/om
-      - name: nix run
-        run: nix run . -- --help
-      - name: Tests
-        # Too slow on rosetta
-        if: matrix.system != 'x86_64-darwin'
-        run: |
-          # We disable some tests (e.g.: omnix-cli tests) on Nix due to
-          # sandboxing issues.
-          nix \
-            --option system "${{ matrix.system }}" \
-            --extra-access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}" \
-            develop -c cargo test
+
+      # Push the Nix cache
       - name: Push to cachix
         if: github.ref == 'refs/heads/main'
         run: nix --option system "${{ matrix.system }}" run .#cachix-push
@@ -89,13 +75,13 @@ jobs:
         # By default, the shell will exit if any command fails. We want to
         # ignore the failure of the om binary using `set +e`.
         run: |
-            set +e
-            chmod +x ./om
-            ./om health
-            if [[ $? -ne 0 ]]; then
-              echo "om binary failed due to lack of nix installation, as expected."
-              exit 0
-            fi
+          set +e
+          chmod +x ./om
+          ./om health
+          if [[ $? -ne 0 ]]; then
+            echo "om binary failed due to lack of nix installation, as expected."
+            exit 0
+          fi
 
   website-build:
     if: github.ref == 'refs/heads/main'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-walkdir"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20235b6899dd1cb74a9afac0abf5b4a20c0e500dd6537280f4096e1b9f14da20"
+dependencies = [
+ "async-fs",
+ "futures-lite",
+ "thiserror",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,14 +1923,13 @@ checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
 ]
@@ -3192,14 +3202,18 @@ name = "nixci"
 version = "1.1.0"
 dependencies = [
  "anyhow",
+ "async-walkdir",
  "clap",
  "colored",
+ "futures-lite",
  "nix_health",
  "nix_rs",
+ "nonempty",
  "reqwest",
  "serde",
  "serde_json",
  "shell-words",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -3214,6 +3228,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nonempty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -4895,18 +4918,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0.75"
+async-walkdir = "2.0.0"
 bytesize = { version = "1.3.0", features = ["serde"] }
 cfg-if = "1"
 clap = { version = "4.3", features = ["derive", "env"] }
@@ -24,6 +25,7 @@ console_log = "1"
 direnv = "0.1.1"
 fermi = "0.4.3"
 flakreate = { version = "0.1.0", path = "./crates/flakreate" }
+futures-lite = "2.3.0"
 glob = "0.3.1"
 http = "0.2"
 human-panic = "1.1.5"
@@ -32,6 +34,7 @@ is_proc_translated = { version = "0.1.1" }
 nixci = { version = "1.1.0", path = "./crates/nixci" }
 nix_health = { version = "1.0.0", path = "./crates/nix_health" }
 nix_rs = { version = "1.0.0", path = "./crates/nix_rs" }
+nonempty = { version = "0.10.0", features = ["serialize"] }
 omnix-common = { version = "0.1.0", path = "./crates/omnix-common" }
 os_info = "3.7.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
@@ -44,6 +47,7 @@ serde_with = { version = "3.2", features = ["json"] }
 shell-words = { version = "1.1.0" }
 sysinfo = "0.29.10"
 tabled = "0.15"
+tempfile = "3"
 thiserror = "1.0"
 tokio = { version = "1.33.0", features = ["full"] }
 tracing = "0.1"

--- a/crates/flakreate/registry/nix/flake-output-cache.nix
+++ b/crates/flakreate/registry/nix/flake-output-cache.nix
@@ -19,6 +19,7 @@
     packages.cache = pkgs.writeShellApplication {
       name = "write-flake-cache";
       text = ''
+        set -x
         cp ${inputs.self.flakeEvalCache} ./flake.nix.json
       '';
     };

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -5,7 +5,8 @@
 - **`flake::url`**
   - Add `without_attr`, `get_attr`
   - Simplify the return type of `RootQualifiedAttr::eval_flake`
-  - Add `AsRef` and `Deref` instances for `FlakeUrl`
+  - Add `AsRef`, `Deref`, `From<&Path>` instances for `FlakeUrl`
+  - `Path` instances for `FlakeUrl` no longer use the `path:` prefix (to avoid store copying)
   - **`attr`**:
     - Add `FlakeAttr::new` and `FlakeAttr::none` constructors
 - **`store`**:

--- a/crates/nix_rs/src/flake/url/attr.rs
+++ b/crates/nix_rs/src/flake/url/attr.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// The (optional) attribute output part of a [super::FlakeUrl]
 ///
 /// Example: `foo` in `.#foo`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FlakeAttr(pub Option<String>);
 
 impl FlakeAttr {

--- a/crates/nixci/CHANGELOG.md
+++ b/crates/nixci/CHANGELOG.md
@@ -3,6 +3,7 @@
 - New
   - Introduced notion of 'steps'. Renamed 'build' to 'run'.
     - Added a step to run `nix flake check`
+    - Support for custom steps
 - `config.rs`: Refactored to change API.
 
 ## 1.1.0

--- a/crates/nixci/Cargo.toml
+++ b/crates/nixci/Cargo.toml
@@ -18,14 +18,18 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = { workspace = true }
+async-walkdir = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
+futures-lite = { workspace = true }
 nix_health = { workspace = true }
 nix_rs = { workspace = true, features = ["clap"] }
+nonempty = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shell-words = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/nixci/src/command/run.rs
+++ b/crates/nixci/src/command/run.rs
@@ -157,26 +157,35 @@ pub async fn ci_run(
         let name = format!("{}.{}", cfg.ref_.selected_name, subflake_name).italic();
 
         if subflake.skip {
-            tracing::info!("🍊 {} {}", name, "skipped (deselected out)".dimmed());
+            tracing::info!("\n🍊 {} {}", name, "skipped (deselected out)".dimmed());
             continue;
         }
 
-        let compatible_system = subflake.can_build_on(&systems);
+        let compatible_system = subflake.can_run_on(&systems);
         if !compatible_system {
             tracing::info!(
-                "🍊 {} {}",
+                "\n🍊 {} {}",
                 name,
-                "skipped (cannot build on this system)".dimmed()
+                "skipped (cannot run on this system)".dimmed()
             );
             continue;
         }
 
-        tracing::info!("🍎 {}", name);
+        tracing::info!("\n🍎 {}", name);
         subflake
             .steps
-            .run(cmd, verbose, run_cmd, &cfg.ref_.flake_url, subflake)
+            .run(
+                cmd,
+                verbose,
+                run_cmd,
+                &systems,
+                &cfg.ref_.flake_url,
+                subflake,
+            )
             .await?;
     }
+
+    tracing::info!("\n🥳 Success!");
 
     Ok(())
 }

--- a/crates/nixci/src/config/subflake.rs
+++ b/crates/nixci/src/config/subflake.rs
@@ -47,8 +47,8 @@ impl Default for SubflakeConfig {
 }
 
 impl SubflakeConfig {
-    /// Whether this subflake can be built on any of the given systems
-    pub fn can_build_on(&self, systems: &[System]) -> bool {
+    /// Whether the CI for this subflake can be run on any of the given systems
+    pub fn can_run_on(&self, systems: &[System]) -> bool {
         match self.systems.as_ref() {
             Some(systems_whitelist) => systems_whitelist.iter().any(|s| systems.contains(s)),
             None => true,

--- a/crates/nixci/src/github/matrix.rs
+++ b/crates/nixci/src/github/matrix.rs
@@ -29,7 +29,7 @@ impl GitHubMatrix {
                 subflakes
                     .0
                     .iter()
-                    .filter(|&(_k, v)| v.can_build_on(&[system.clone()]))
+                    .filter(|&(_k, v)| v.can_run_on(&[system.clone()]))
                     .map(|(k, _v)| GitHubMatrixRow {
                         system: system.clone(),
                         subflake: k.clone(),

--- a/crates/nixci/src/step/custom.rs
+++ b/crates/nixci/src/step/custom.rs
@@ -1,0 +1,236 @@
+//! Custom steps in the CI pipeline
+use async_walkdir::WalkDir;
+use colored::Colorize;
+use futures_lite::{stream::StreamExt, Future};
+use nonempty::NonEmpty;
+use serde::Deserialize;
+use std::{
+    collections::BTreeMap,
+    fs::Permissions,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+};
+use tokio::fs;
+
+use nix_rs::{
+    command::NixCmd,
+    flake::{
+        metadata::FlakeMetadata,
+        system::System,
+        url::{attr::FlakeAttr, FlakeUrl},
+    },
+};
+
+use crate::config::subflake::SubflakeConfig;
+
+/// Represents a custom step in the CI pipeline
+///
+/// All these commands are run in the same directory as the subflake
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum CustomStep {
+    /// A flake app to run
+    #[serde(rename = "app")]
+    FlakeApp {
+        /// Name of the app
+        #[serde(default)]
+        name: FlakeAttr,
+        /// Arguments to pass to the app
+        #[serde(default)]
+        args: Vec<String>,
+        /// Whitelist of systems to run on
+        systems: Option<Vec<System>>,
+    },
+
+    /// An arbitrary command to run in the devshell
+    #[serde(rename = "devshell")]
+    FlakeDevShellCommand {
+        /// Name of the devShell
+        #[serde(default)]
+        name: FlakeAttr,
+        /// The command to run inside of devshell
+        command: NonEmpty<String>,
+        /// Whitelist of systems to run on
+        systems: Option<Vec<System>>,
+    },
+}
+
+impl CustomStep {
+    /// Run this step
+    pub async fn run(
+        &self,
+        nixcmd: &NixCmd,
+        url: &FlakeUrl,
+        subflake: &SubflakeConfig,
+    ) -> anyhow::Result<()> {
+        with_writeable_flake_dir(nixcmd, url, |flake_path| async move {
+            self.run_on_local_path(nixcmd, flake_path, subflake).await
+        })
+        .await
+    }
+
+    /// Like [run] but runs on a flake that is known to be at a local path
+    async fn run_on_local_path(
+        &self,
+        nixcmd: &NixCmd,
+        flake_path: PathBuf,
+        subflake: &SubflakeConfig,
+    ) -> anyhow::Result<()> {
+        let path = flake_path.join(&subflake.dir);
+        tracing::info!("Running custom step under: {:}", &path.display());
+
+        // TODO: Refactor and upstream to nix_rs? We may want to add support for --override-inputs in nix_rs's `Command` though. Usae that throughout even when building through devour-flake.
+        let mut cmd = nixcmd.command();
+        cmd.args(
+            subflake
+                .override_inputs
+                .iter()
+                .flat_map(|(k, v)| vec!["--override-input", k, &v]),
+        );
+
+        cmd.current_dir(&path);
+        let pwd_flake = FlakeUrl::from(PathBuf::from("."));
+
+        // Pass arguments specific `nix run` and `nix develop`
+        match self {
+            CustomStep::FlakeApp { name, args, .. } => {
+                cmd.arg("run")
+                    .arg(pwd_flake.with_attr(&name.get_name()).to_string())
+                    .arg("--")
+                    .args(args);
+            }
+            CustomStep::FlakeDevShellCommand { name, command, .. } => {
+                cmd.arg("develop")
+                    .arg(pwd_flake.with_attr(&name.get_name()).to_string())
+                    .arg("-c")
+                    .args(command);
+            }
+        };
+
+        // Run
+        nix_rs::command::trace_cmd(&cmd);
+        let status = cmd.spawn()?.wait().await?;
+        Ok(status.exit_ok()?)
+    }
+
+    fn can_run_on(&self, systems: &[System]) -> bool {
+        match self.get_systems() {
+            Some(systems_whitelist) => systems_whitelist.iter().any(|s| systems.contains(s)),
+            None => true,
+        }
+    }
+
+    fn get_systems(&self) -> &Option<Vec<System>> {
+        match self {
+            CustomStep::FlakeApp { systems, .. } => systems,
+            CustomStep::FlakeDevShellCommand { systems, .. } => systems,
+        }
+    }
+}
+
+/// A collection of custom steps
+#[derive(Debug, Default, Deserialize)]
+pub struct CustomSteps(BTreeMap<String, CustomStep>);
+
+impl CustomSteps {
+    /// Run all custom steps
+    pub async fn run(
+        &self,
+        nixcmd: &NixCmd,
+        systems: &[System],
+        url: &FlakeUrl,
+        subflake: &SubflakeConfig,
+    ) -> anyhow::Result<()> {
+        for (name, step) in &self.0 {
+            if step.can_run_on(systems) {
+                tracing::info!("{}", format!("🏗  Running custom step: {}", name).bold());
+                step.run(nixcmd, url, subflake).await?;
+            } else {
+                tracing::info!(
+                  "{}",
+                  format!(
+                      "🏗  Skipping custom step {} because it's not whitelisted for the current system: {:?}",
+                      name,
+                      systems.iter().map(|s| s.to_string()).collect::<Vec<_>>()
+                  )
+                  .yellow()
+              );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Call the given function with a (write-able) local path equivalent to the given URL
+///
+/// The flake is retrieved locally, and stored in a temp directory is created if necessary.
+///
+/// Two reasons for copying to a temp (and writeable) directory:
+/// 1. `nix run` does not work reliably on store paths (`/nix/store/**`)
+/// 2. `nix develop -c ...` often requires mutable flake directories
+async fn with_writeable_flake_dir<F, Fut>(
+    nixcmd: &NixCmd,
+    url: &FlakeUrl,
+    f: F,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(PathBuf) -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+{
+    // First, ensure that flake is locally available.
+    let local_path = match url.as_local_path() {
+        Some(local_path) => local_path.to_path_buf(),
+        None => FlakeMetadata::from_nix(nixcmd, url).await?.path,
+    };
+
+    // Then, ensure that it is writeable by the user
+    let read_only = local_path.metadata()?.permissions().readonly();
+    let path = if read_only {
+        // Two reasons for copying to a temp location:
+        // 1. `nix run` does not work reliably on store paths
+        // 2. `nix develop -c ...` often require mutable flake directories
+        let target_path = tempfile::Builder::new()
+            .prefix("om-ci-")
+            .tempdir()?
+            .path()
+            .join("flake");
+        copy_dir_all(&local_path, &target_path).await?;
+        target_path
+    } else {
+        local_path
+    };
+
+    // Finally, call the function with the path
+    f(path).await
+}
+
+/// Copy a directory recursively
+///
+/// The target directory will always be user readable & writable.
+async fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> anyhow::Result<()> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+
+    let mut walker = WalkDir::new(src);
+
+    while let Some(entry) = walker.next().await {
+        let entry = entry?;
+        let path = &entry.path();
+        let relative = path.strip_prefix(src)?;
+        let target = dst.join(relative);
+
+        if entry.file_type().await?.is_dir() {
+            fs::create_dir_all(&target).await?;
+            fs::set_permissions(&target, Permissions::from_mode(0o755)).await?;
+        } else {
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent).await?;
+                fs::set_permissions(&parent, Permissions::from_mode(0o755)).await?;
+            }
+            fs::copy(path, &target).await?;
+            fs::set_permissions(&target, Permissions::from_mode(0o644)).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/nixci/src/step/mod.rs
+++ b/crates/nixci/src/step/mod.rs
@@ -1,5 +1,6 @@
 //! CI is broken down into various 'steps'.
 pub mod build;
 pub mod core;
+pub mod custom;
 pub mod flake_check;
 pub mod lockfile;

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -9,7 +9,9 @@
 - `om ci`
   - Support for remote builds over SSH (via `--on` option)
   - Avoid running `nix-store` command multiple times (#224)
-  - Run `nix flake check` on all subflakes (#200)
+  - Support for CI steps
+    - Run `nix flake check` on all subflakes (#200)
+    - Ability to add a custom CI step. For example, to run arbitrary commands.
 
 ### Fixes
 

--- a/justfile
+++ b/justfile
@@ -43,5 +43,9 @@ test-cli:
 ci:
     nix run . ci
 
+# Run CI locally in devShell (thus, using cargo)
+ci-cargo:
+    cargo run -p omnix-cli -- ci run
+
 clippy:
     cargo clippy --release --locked --all-targets --all-features -- --deny warnings

--- a/nix/modules/closure-size.nix
+++ b/nix/modules/closure-size.nix
@@ -10,6 +10,7 @@ in
       runtimeInputs = [ pkgs.jq pkgs.bc pkgs.nix ];
       meta.description = "Check that omnix's nix closure size remains reasonably small";
       text = ''
+        set -o pipefail
         MAX_CLOSURE_SIZE=$(echo "${builtins.toString maxSizeInMB} * 1000000" | bc)
         CLOSURE_SIZE=$(nix path-info --json -S .#default | jq '.[0]'.closureSize)
         echo "Omnix closure size: $CLOSURE_SIZE"

--- a/nix/modules/om.nix
+++ b/nix/modules/om.nix
@@ -8,8 +8,38 @@ in
   flake = {
     om = {
       ci.default = {
-        omnix.dir = ".";
-        flakreate-registry.dir = "crates/flakreate/registry";
+        omnix = {
+          dir = ".";
+          steps = {
+            # build.enable = false;
+            flake-check.enable = false; # Not necessary
+            custom = {
+              cli-runs = {
+                type = "app";
+                # name = "default";
+                args = [ "--help" ];
+              };
+              binary-size-is-small = {
+                type = "app";
+                name = "check-closure-size";
+                systems = [ "x86_64-linux" ]; # We have static binary for Linux only.
+              };
+              cargo-tests = {
+                type = "devshell";
+                # name = "default";
+                command = [ "cargo" "test" ];
+                systems = [ "x86_64-linux" "aarch64-darwin" ]; # Too slow on rosetta
+              };
+            };
+          };
+        };
+        flakreate-registry = {
+          dir = "crates/flakreate/registry";
+          steps.custom.demo = {
+            type = "app";
+            name = "cache";
+          };
+        };
         doc.dir = "doc";
 
         # Because the cargo tests invoking Nix doesn't pass github access tokens..


### PR DESCRIPTION
Wherein the user can configure their flake to either run a flake app or an arbitrary command in the devShell (for any subflake).

Also, remove `path:` prefixing in `FlakeUrl`, because it triggers copying to Nix store (including even git ignored paths!)

ci.yaml no longer runs what is now handled by `om ci run`.

Resolves #198