### PR TITLE
nix_rs: Introduce `flake::command` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "clap",
  "colored",
  "is_proc_translated",
+ "nonempty",
  "os_info",
  "regex",
  "serde",

--- a/crates/flakreate/src/lib.rs
+++ b/crates/flakreate/src/lib.rs
@@ -25,7 +25,9 @@ pub async fn flakreate(registry: FlakeUrl, path: PathBuf) -> anyhow::Result<()> 
     let template_url = registry.with_attr(&template.name);
     NixCmd::get()
         .await
-        .run_with_args(&["flake", "new", &path, "-t", &template_url.0])
+        .run_with(|cmd| {
+            cmd.args(["flake", "new", &path, "-t", &template_url.0]);
+        })
         .await?;
 
     // Do the actual replacement

--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -17,8 +17,10 @@
   - `NixEnv::detect`'s logging uses DEBUG level now (formerly INFO)
   - Add Nix installer to `NixEnv`
 - **`command`
-  - `run_with_args` now takes an iterator of string references, much like `Command::args`.
+  - `run_with_args` is now `run_with`, and takes a function that mutates the `Command` at will.
   - Add `trace_cmd_with`
+- **`flake::command`**:
+  - Add module, for `nix run` and `nix develop`
 
 ## 1.0.0
 

--- a/crates/nix_rs/Cargo.toml
+++ b/crates/nix_rs/Cargo.toml
@@ -29,6 +29,7 @@ is_proc_translated = { workspace = true }
 sysinfo = { workspace = true }
 bytesize = { workspace = true }
 clap = { workspace = true, optional = true }
+nonempty = { workspace = true }
 
 [features]
 clap = ["dep:clap"]

--- a/crates/nix_rs/src/command.rs
+++ b/crates/nix_rs/src/command.rs
@@ -8,10 +8,7 @@
 //! cmd.run_with_args_returning_stdout(&["--version"]);
 //! ```
 
-use std::{
-    ffi::OsStr,
-    fmt::{self, Display},
-};
+use std::fmt::{self, Display};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -155,14 +152,13 @@ impl NixCmd {
         }
     }
 
-    /// Run nix with given args, letting stdout and stderr be that of parent process
-    pub async fn run_with_args<I, S>(&self, args: I) -> Result<(), CommandError>
+    /// Run Nix with given [Command] customizations, while also tracing the command being run.
+    pub async fn run_with<F>(&self, f: F) -> Result<(), CommandError>
     where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
+        F: FnOnce(&mut Command),
     {
         let mut cmd = self.command();
-        cmd.args(args);
+        f(&mut cmd);
         trace_cmd(&cmd);
         let status = cmd.spawn()?.wait().await?;
         if status.success() {

--- a/crates/nix_rs/src/copy.rs
+++ b/crates/nix_rs/src/copy.rs
@@ -24,5 +24,8 @@ pub async fn nix_copy(
     for path in paths {
         args.push(path.to_string_lossy().into_owned());
     }
-    cmd.run_with_args(&args).await
+    cmd.run_with(|cmd| {
+        cmd.args(args);
+    })
+    .await
 }

--- a/crates/nix_rs/src/flake/command.rs
+++ b/crates/nix_rs/src/flake/command.rs
@@ -1,0 +1,62 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use nonempty::NonEmpty;
+use tokio::process::Command;
+
+use crate::command::{CommandError, NixCmd};
+
+use super::url::FlakeUrl;
+
+/// Run `nix run` on the given flake app.
+pub async fn run(
+    nixcmd: &NixCmd,
+    opts: &FlakeOptions,
+    url: &FlakeUrl,
+    args: Vec<String>,
+) -> Result<(), CommandError> {
+    nixcmd
+        .run_with(|cmd| {
+            opts.use_in_command(cmd);
+            cmd.args(["run".to_string(), url.to_string(), "--".to_string()]);
+            cmd.args(args);
+        })
+        .await
+}
+
+/// Run `nix develop` on the given flake devshell.
+pub async fn develop(
+    nixcmd: &NixCmd,
+    opts: &FlakeOptions,
+    url: &FlakeUrl,
+    command: NonEmpty<String>,
+) -> Result<(), CommandError> {
+    nixcmd
+        .run_with(|cmd| {
+            opts.use_in_command(cmd);
+            cmd.args(["develop".to_string(), url.to_string(), "-c".to_string()]);
+            cmd.args(command);
+        })
+        .await
+}
+
+/// Nix CLI options when interacting with a flake
+#[derive(Debug, Clone)]
+pub struct FlakeOptions {
+    /// The --override-input option to pass to Nix
+    pub override_inputs: BTreeMap<String, FlakeUrl>,
+
+    /// The directory from which to run our nix command (such that relative flake URLs resolve properly)
+    pub current_dir: Option<PathBuf>,
+}
+
+impl FlakeOptions {
+    /// Apply these options to a (Nix) [Command]
+    fn use_in_command(&self, cmd: &mut Command) {
+        if let Some(curent_dir) = &self.current_dir {
+            cmd.current_dir(curent_dir);
+        }
+        for (name, url) in self.override_inputs.iter() {
+            cmd.arg("--override-input").arg(name).arg(url.to_string());
+        }
+    }
+}

--- a/crates/nix_rs/src/flake/mod.rs
+++ b/crates/nix_rs/src/flake/mod.rs
@@ -1,5 +1,6 @@
 //! Rust module for Nix flakes
 
+pub mod command;
 pub mod eval;
 pub mod metadata;
 pub mod outputs;

--- a/crates/nixci/src/step/flake_check.rs
+++ b/crates/nixci/src/step/flake_check.rs
@@ -37,7 +37,11 @@ impl FlakeCheckStep {
         for (k, v) in &subflake.override_inputs {
             args.extend(["--override-input", k, v]);
         }
-        nixcmd.run_with_args(args).await?;
+        nixcmd
+            .run_with(|cmd| {
+                cmd.args(args);
+            })
+            .await?;
         Ok(())
     }
 }


### PR DESCRIPTION
For invoking `nix run`, `nix develop` and (potentially in future) other flake commands.