### PR TITLE
omnix-cli: Enable cargo library

### DIFF
--- a/crates/omnix-cli/Cargo.toml
+++ b/crates/omnix-cli/Cargo.toml
@@ -8,6 +8,9 @@ homepage = "https://omnix.page"
 repository = "https://github.com/juspay/omnix"
 license = "AGPL-3.0-only"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [[bin]]
 name = "om"
 path = "src/main.rs"

--- a/crates/omnix-cli/src/args.rs
+++ b/crates/omnix-cli/src/args.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+
+use crate::command::Command;
+
+/// Omnix <https://omnix.page/>
+//
+// NOTE: Should we put this in `omnix` crate, and share with `omnix-gui` (see
+// `omnix-gui/src/cli.rs`)?
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[command(flatten)]
+    pub verbosity: Verbosity<InfoLevel>,
+
+    #[clap(subcommand)]
+    pub command: Command,
+}

--- a/crates/omnix-cli/src/args.rs
+++ b/crates/omnix-cli/src/args.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 
-use crate::command::Command;
+use crate::command::core::Command;
 
 /// Omnix <https://omnix.page/>
 //

--- a/crates/omnix-cli/src/command/completion.rs
+++ b/crates/omnix-cli/src/command/completion.rs
@@ -1,4 +1,3 @@
-use crate::Args;
 use clap::CommandFactory;
 use clap::Parser;
 use clap_complete::generate;
@@ -18,7 +17,7 @@ impl CompletionCommand {
 }
 
 pub fn generate_completion(shell: Shell) -> anyhow::Result<()> {
-    let mut cli = Args::command();
+    let mut cli = crate::args::Args::command();
     generate(shell, &mut cli, "om", &mut std::io::stdout());
     Ok(())
 }

--- a/crates/omnix-cli/src/command/core.rs
+++ b/crates/omnix-cli/src/command/core.rs
@@ -1,0 +1,32 @@
+use clap::Subcommand;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    Show(super::show::ShowCommand),
+
+    Init(super::init::InitCommand),
+
+    CI(super::ci::CICommand),
+
+    Health(super::health::HealthCommand),
+
+    Completion(super::completion::CompletionCommand),
+}
+
+impl Command {
+    pub async fn run(&self, verbosity: Verbosity<InfoLevel>) -> anyhow::Result<()> {
+        if !matches!(self, Command::Completion(_)) && !omnix_common::check::nix_installed() {
+            tracing::error!("Nix is not installed: https://nixos.asia/en/install");
+            std::process::exit(1);
+        }
+
+        match self {
+            Command::Show(cmd) => cmd.run().await,
+            Command::Init(cmd) => cmd.run().await,
+            Command::CI(cmd) => cmd.run(verbosity).await,
+            Command::Health(cmd) => cmd.run().await,
+            Command::Completion(cmd) => cmd.run(),
+        }
+    }
+}

--- a/crates/omnix-cli/src/command/mod.rs
+++ b/crates/omnix-cli/src/command/mod.rs
@@ -1,11 +1,11 @@
-use clap::Subcommand;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
-
 pub mod ci;
-mod completion;
+pub mod completion;
 pub mod health;
 pub mod init;
 pub mod show;
+
+use clap::Subcommand;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
 
 #[derive(Subcommand, Debug)]
 pub enum Command {

--- a/crates/omnix-cli/src/command/mod.rs
+++ b/crates/omnix-cli/src/command/mod.rs
@@ -1,38 +1,6 @@
 pub mod ci;
 pub mod completion;
+pub mod core;
 pub mod health;
 pub mod init;
 pub mod show;
-
-use clap::Subcommand;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
-
-#[derive(Subcommand, Debug)]
-pub enum Command {
-    Show(show::ShowCommand),
-
-    Init(init::InitCommand),
-
-    CI(ci::CICommand),
-
-    Health(health::HealthCommand),
-
-    Completion(completion::CompletionCommand),
-}
-
-impl Command {
-    pub async fn run(&self, verbosity: Verbosity<InfoLevel>) -> anyhow::Result<()> {
-        if !matches!(self, Command::Completion(_)) && !omnix_common::check::nix_installed() {
-            tracing::error!("Nix is not installed: https://nixos.asia/en/install");
-            std::process::exit(1);
-        }
-
-        match self {
-            Command::Show(cmd) => cmd.run().await,
-            Command::Init(cmd) => cmd.run().await,
-            Command::CI(cmd) => cmd.run(verbosity).await,
-            Command::Health(cmd) => cmd.run().await,
-            Command::Completion(cmd) => cmd.run(),
-        }
-    }
-}

--- a/crates/omnix-cli/src/lib.rs
+++ b/crates/omnix-cli/src/lib.rs
@@ -1,0 +1,3 @@
+#![feature(lazy_cell)]
+pub mod args;
+pub mod command;

--- a/crates/omnix-cli/src/main.rs
+++ b/crates/omnix-cli/src/main.rs
@@ -1,26 +1,9 @@
-#![feature(lazy_cell)]
 use clap::Parser;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
-
-mod command;
-
-/// Omnix <https://omnix.page/>
-//
-// NOTE: Should we put this in `omnix` crate, and share with `omnix-gui` (see
-// `omnix-gui/src/cli.rs`)?
-#[derive(Parser, Debug)]
-pub struct Args {
-    #[command(flatten)]
-    pub verbosity: Verbosity<InfoLevel>,
-
-    #[clap(subcommand)]
-    pub command: command::Command,
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     human_panic::setup_panic!();
-    let args = Args::parse();
+    let args = omnix_cli::args::Args::parse();
     let verbose = args.verbosity.log_level() > Some(clap_verbosity_flag::Level::Info);
     omnix_common::logging::setup_logging(&args.verbosity, !verbose);
     tracing::debug!("Args: {:?}", args);


### PR DESCRIPTION
The plan is to write tests using the library API, rather than invoking the CLI, so we may test behaviour for all frontends (CLI, web).