### PR TITLE
refactor(nix): DRY up crate args

### DIFF
--- a/crates/flakreate/crate.nix
+++ b/crates/flakreate/crate.nix
@@ -11,5 +11,10 @@
         IOKit
       ]
     );
+    OM_INIT_REGISTRY =
+      lib.cleanSourceWith {
+        name = "flakreate-registry";
+        src = flake.inputs.self + /crates/flakreate/registry;
+      };
   };
 }

--- a/crates/nix_health/crate.nix
+++ b/crates/nix_health/crate.nix
@@ -18,9 +18,11 @@ in
           CoreFoundation
         ]
       );
-      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
-      inherit (rust-project.crates."omnix-cli".crane.args)
-        DEFAULT_FLAKE_SCHEMAS;
+      inherit (rust-project.crates."nix_rs".crane.args)
+        DEVOUR_FLAKE
+        DEFAULT_FLAKE_SCHEMAS
+        NIX_FLAKE_SCHEMAS_BIN
+        ;
       nativeBuildInputs = with pkgs; [
         nix # Tests need nix cli
       ];

--- a/crates/nix_rs/crate.nix
+++ b/crates/nix_rs/crate.nix
@@ -20,9 +20,12 @@ in
       nativeBuildInputs = with pkgs; [
         nix # Tests need nix cli
       ];
+      DEVOUR_FLAKE = inputs.devour-flake;
+      DEFAULT_FLAKE_SCHEMAS = lib.cleanSourceWith {
+        name = "flake-schemas";
+        src = flake.inputs.self + /nix/flake-schemas;
+      };
       NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
-      inherit (rust-project.crates."omnix-cli".crane.args)
-        DEFAULT_FLAKE_SCHEMAS;
     };
   };
 }

--- a/crates/nixci/crate.nix
+++ b/crates/nixci/crate.nix
@@ -31,11 +31,12 @@ in
       # Disable tests due to sandboxing issues; we run them on CI
       # instead.
       doCheck = false;
-      DEVOUR_FLAKE = inputs.devour-flake;
+      inherit (rust-project.crates."nix_rs".crane.args)
+        DEVOUR_FLAKE
+        DEFAULT_FLAKE_SCHEMAS
+        NIX_FLAKE_SCHEMAS_BIN
+        ;
       OMNIX_SOURCE = inputs.self;
-      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
-      inherit (rust-project.crates."omnix-cli".crane.args)
-        DEFAULT_FLAKE_SCHEMAS;
     };
   };
 }

--- a/crates/omnix-cli/crate.nix
+++ b/crates/omnix-cli/crate.nix
@@ -34,18 +34,19 @@ in
         ) ++ lib.optionals pkgs.stdenv.isLinux [
         pkgsStatic.openssl
       ];
-      OM_INIT_REGISTRY =
-        lib.cleanSourceWith {
-          name = "flakreate-registry";
-          src = flake.inputs.self + /crates/flakreate/registry;
-        };
-      DEFAULT_FLAKE_SCHEMAS = lib.cleanSourceWith {
-        name = "flake-schemas";
-        src = flake.inputs.self + /nix/flake-schemas;
-      };
-      DEVOUR_FLAKE = inputs.devour-flake;
-      OMNIX_SOURCE = inputs.self;
-      NIX_FLAKE_SCHEMAS_BIN = lib.getExe pkgs.nix-flake-schemas;
+
+      inherit (rust-project.crates."nix_rs".crane.args)
+        DEVOUR_FLAKE
+        DEFAULT_FLAKE_SCHEMAS
+        NIX_FLAKE_SCHEMAS_BIN
+        ;
+      inherit (rust-project.crates."nixci".crane.args)
+        OMNIX_SOURCE
+        ;
+      inherit (rust-project.crates."flakreate".crane.args)
+        OM_INIT_REGISTRY
+        ;
+
       # Disable tests due to sandboxing issues; we run them on CI
       # instead.
       doCheck = false;


### PR DESCRIPTION
Avoid duplicating library crate's build dependency code in the caller's crate.nix. This is what `config.rust-project` is for.

Ultimately, we can streamline this further using https://github.com/juspay/rust-flake/issues/14