### PR TITLE
Use granular autoWiring

### DIFF
--- a/crates/flakreate/crate.nix
+++ b/crates/flakreate/crate.nix
@@ -5,6 +5,7 @@
 }:
 
 {
+  autoWire = [ ];
   crane.args = {
     buildInputs = lib.optionals pkgs.stdenv.isDarwin (
       with pkgs.apple_sdk_frameworks; [

--- a/crates/nix_health/crate.nix
+++ b/crates/nix_health/crate.nix
@@ -9,6 +9,7 @@ let
   inherit (flake) inputs;
 in
 {
+  autoWire = [ "doc" "clippy" ];
   crane = {
     args = {
       buildInputs = lib.optionals pkgs.stdenv.isDarwin (

--- a/crates/nix_rs/crate.nix
+++ b/crates/nix_rs/crate.nix
@@ -9,6 +9,7 @@ let
   inherit (flake) inputs;
 in
 {
+  autoWire = [ "doc" "clippy" ];
   crane = {
     args = {
       nativeBuildInputs = with pkgs; [

--- a/crates/nixci/crate.nix
+++ b/crates/nixci/crate.nix
@@ -9,6 +9,7 @@ let
   inherit (flake) inputs;
 in
 {
+  autoWire = [ "doc" "clippy" ];
   crane = {
     args = {
       nativeBuildInputs = with pkgs; with pkgs.apple_sdk_frameworks; lib.optionals stdenv.isDarwin [

--- a/crates/omnix-cli/crate.nix
+++ b/crates/omnix-cli/crate.nix
@@ -10,7 +10,7 @@ let
   inherit (pkgs) stdenv pkgsStatic;
 in
 {
-  autoWire = false;
+  autoWire = [ "doc" "clippy" ];
   crane = {
     args = {
       nativeBuildInputs = with pkgs.apple_sdk_frameworks; lib.optionals stdenv.isDarwin [

--- a/crates/omnix-common/crate.nix
+++ b/crates/omnix-common/crate.nix
@@ -6,6 +6,7 @@
 }:
 
 {
+  autoWire = [ "doc" "clippy" ];
   crane = {
     args = {
       inherit (rust-project.crates."nix_rs".crane.args)

--- a/crates/omnix-gui/crate.nix
+++ b/crates/omnix-gui/crate.nix
@@ -9,7 +9,7 @@ let
   inherit (flake) inputs;
 in
 {
-  autoWire = false;
+  autoWire = [ ];
   crane = {
     args = {
       buildInputs = lib.optionals pkgs.stdenv.isLinux

--- a/flake.lock
+++ b/flake.lock
@@ -311,15 +311,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1725308311,
-        "narHash": "sha256-Wk+3IfHWvm21Lp5MTjwCEPY2tTdxiojxfhVuBIiN4vU=",
+        "lastModified": 1725522236,
+        "narHash": "sha256-dP8ie2arXvvNzn5uqHGf3r0x5pfHm4d5rIg3j1fpwcA=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "e922400c13f7469d4ccaccb4d545aa75e69629a5",
+        "rev": "ea2bdf67ec3924adb0361630365c34ba8bc11ad9",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
+        "ref": "granular-autoWire",
         "repo": "rust-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     systems.url = "github:nix-systems/default";
 
-    rust-flake.url = "github:juspay/rust-flake";
+    rust-flake.url = "github:juspay/rust-flake/granular-autoWire";
     rust-flake.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -16,19 +16,6 @@
       crateNixFile = "crate.nix";
     };
 
-    checks =
-      let
-        inherit (config.rust-project) crates;
-      in
-      {
-        # Clippy checks
-        # TODO: Remove after https://github.com/juspay/rust-flake/issues/23
-        omnix-cli-clippy = crates."omnix-cli".crane.outputs.drv.clippy;
-        omnix-common-clippy = crates."omnix-common".crane.outputs.drv.clippy;
-        nix_rs-clippy = crates."nix_rs".crane.outputs.drv.clippy;
-        nixci-clippy = crates."nixci".crane.outputs.drv.clippy;
-        nix_health-clippy = crates."nix_health".crane.outputs.drv.clippy;
-      };
 
     packages =
       let
@@ -46,13 +33,6 @@
           '';
         });
 
-        # Rust docs
-        # TODO: Remove after https://github.com/juspay/rust-flake/issues/23
-        omnix-cli-doc = crates."omnix-cli".crane.outputs.drv.doc;
-        omnix-common-doc = crates."omnix-common".crane.outputs.drv.doc;
-        nix_rs-doc = crates."nix_rs".crane.outputs.drv.doc;
-        nixci-doc = crates."nixci".crane.outputs.drv.doc;
-        nix_health-doc = crates."nix_health".crane.outputs.drv.doc;
 
         /*
         gui = crates."omnix-gui".crane.outputs.drv.crate.overrideAttrs (oa: {


### PR DESCRIPTION
use granular autoWiring for flake output.

https://github.com/juspay/rust-flake/pull/24

Before bumping up rust-flake:

<img width="1440" alt="Screenshot 2024-09-05 at 1 56 04 PM" src="https://github.com/user-attachments/assets/4fcc2687-f12a-4af2-89cd-794dbb9f0095">

After bumping up rust-flake:

<img width="1440" alt="Screenshot 2024-09-05 at 1 58 20 PM" src="https://github.com/user-attachments/assets/b05ca804-62dc-4822-bbde-21f94a4b2d6f">
