### PR TITLE
omnix-init: use `lazy_cell` feature

### DIFF
--- a/crates/omnix-init/src/lib.rs
+++ b/crates/omnix-init/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(lazy_cell)]
 pub mod action;
 pub mod config;
 pub mod core;


### PR DESCRIPTION
This is to bypass:
```sh
error[E0658]: use of unstable library feature 'lazy_cell'
 --> crates/omnix-init/src/config.rs:1:48
  |
1 | use std::{collections::HashMap, path::PathBuf, sync::LazyLock};
  |                                                ^^^^^^^^^^^^^^
  |
  = note: see issue #109736
<https://github.com/rust-lang/rust/issues/109736> for more information
  = help: add `#![feature(lazy_cell)]` to the crate attributes to enable
  = note: this compiler was built on 2024-05-11; consider upgrading it
if it is out of date
```