### PR TITLE
`om ci` JSON output

### DIFF
--- a/crates/nix_rs/src/store/command.rs
+++ b/crates/nix_rs/src/store/command.rs
@@ -32,11 +32,9 @@ impl NixStoreCmd {
     /// `Vec<StorePath>`.
     pub async fn fetch_all_deps(
         &self,
-        out_paths: HashSet<StorePath>,
+        out_paths: Vec<StorePath>,
     ) -> Result<HashSet<StorePath>, NixStoreCmdError> {
-        let all_drvs = self
-            .nix_store_query_deriver(&out_paths.iter().cloned().collect::<Vec<_>>())
-            .await?;
+        let all_drvs = self.nix_store_query_deriver(&out_paths).await?;
         let all_outs = self
             .nix_store_query_requisites_with_outputs(&all_drvs)
             .await?;

--- a/crates/nix_rs/src/store/command.rs
+++ b/crates/nix_rs/src/store/command.rs
@@ -1,5 +1,5 @@
 /// Rust wrapper for `nix-store`
-use std::{collections::HashSet, path::PathBuf};
+use std::path::PathBuf;
 
 use crate::command::{CommandError, NixCmdError};
 use serde::{Deserialize, Serialize};
@@ -32,13 +32,13 @@ impl NixStoreCmd {
     /// `Vec<StorePath>`.
     pub async fn fetch_all_deps(
         &self,
-        out_paths: Vec<StorePath>,
-    ) -> Result<HashSet<StorePath>, NixStoreCmdError> {
+        out_paths: &[StorePath],
+    ) -> Result<Vec<StorePath>, NixStoreCmdError> {
         let all_drvs = self.nix_store_query_deriver(&out_paths).await?;
         let all_outs = self
             .nix_store_query_requisites_with_outputs(&all_drvs)
             .await?;
-        Ok(all_outs.into_iter().collect())
+        Ok(all_outs)
     }
 
     /// Return the derivations used to build the given build output.

--- a/crates/nix_rs/src/store/command.rs
+++ b/crates/nix_rs/src/store/command.rs
@@ -34,7 +34,7 @@ impl NixStoreCmd {
         &self,
         out_paths: &[StorePath],
     ) -> Result<Vec<StorePath>, NixStoreCmdError> {
-        let all_drvs = self.nix_store_query_deriver(&out_paths).await?;
+        let all_drvs = self.nix_store_query_deriver(out_paths).await?;
         let all_outs = self
             .nix_store_query_requisites_with_outputs(&all_drvs)
             .await?;

--- a/crates/nix_rs/src/store/path.rs
+++ b/crates/nix_rs/src/store/path.rs
@@ -1,14 +1,26 @@
 /// Store path management
-use std::{fmt, path::PathBuf};
+use std::{convert::Infallible, fmt, path::PathBuf, str::FromStr};
+
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 /// Represents a path in the Nix store, see: <https://zero-to-nix.com/concepts/nix-store#store-paths>
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash)]
+#[derive(
+    Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, DeserializeFromStr, SerializeDisplay,
+)]
 pub enum StorePath {
     /// Derivation path (ends with `.drv`).
     Drv(PathBuf),
     /// Other paths in the Nix store, such as build outputs.
     /// This won't be a derivation path.
     Other(PathBuf),
+}
+
+impl FromStr for StorePath {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(StorePath::new(PathBuf::from(s)))
+    }
 }
 
 impl From<&StorePath> for PathBuf {

--- a/crates/nixci/src/command/run.rs
+++ b/crates/nixci/src/command/run.rs
@@ -110,7 +110,9 @@ impl RunCommand {
         if self.json {
             println!("{}", serde_json::to_string(&res)?);
         } else {
-            // res.print();
+            for (_, result) in res {
+                result.print();
+            }
         }
 
         Ok(())

--- a/crates/nixci/src/nix/devour_flake.rs
+++ b/crates/nixci/src/nix/devour_flake.rs
@@ -5,10 +5,7 @@
 use anyhow::{bail, Context, Result};
 use nix_rs::{command::NixCmd, flake::url::FlakeUrl, store::path::StorePath};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    process::Stdio,
-};
+use std::{collections::HashMap, process::Stdio};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 /// Absolute path to the devour-flake flake source
@@ -28,10 +25,11 @@ pub struct DevourFlakeOutput {
     /// The built store paths
     ///
     /// This includes all dependencies if --print-all-dependencies was passed.
-    #[serde(rename = "out-paths")]
-    pub out_paths: HashSet<StorePath>,
+    #[serde(rename = "outPaths")]
+    pub out_paths: Vec<StorePath>,
 
-    #[serde(rename = "by-name")]
+    /// Output paths indexed by name (or pname) of the path if any
+    #[serde(rename = "byName")]
     pub by_name: HashMap<String, StorePath>,
 }
 

--- a/crates/nixci/src/nix/devour_flake.rs
+++ b/crates/nixci/src/nix/devour_flake.rs
@@ -23,8 +23,6 @@ pub struct DevourFlakeInput {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DevourFlakeOutput {
     /// The built store paths
-    ///
-    /// This includes all dependencies if --print-all-dependencies was passed.
     #[serde(rename = "outPaths")]
     pub out_paths: Vec<StorePath>,
 

--- a/crates/nixci/src/nix/devour_flake.rs
+++ b/crates/nixci/src/nix/devour_flake.rs
@@ -34,8 +34,12 @@ pub struct DevourFlakeOutput {
 impl DevourFlakeOutput {
     fn from_drv(drv_out: &str) -> anyhow::Result<Self> {
         // Read drv_out file as JSON, decoding it into DevourFlakeOutput
-        let out: DevourFlakeOutput = serde_json::from_reader(std::fs::File::open(drv_out)?)
+        let mut out: DevourFlakeOutput = serde_json::from_reader(std::fs::File::open(drv_out)?)
             .context("Failed to parse devour-flake output")?;
+        // Remove duplicates, which is possible in user's flake
+        // e.g., when doing `packages.foo = self'.packages.default`
+        out.out_paths.sort();
+        out.out_paths.dedup();
         Ok(out)
     }
 }

--- a/crates/nixci/src/nix/devour_flake.rs
+++ b/crates/nixci/src/nix/devour_flake.rs
@@ -20,7 +20,7 @@ pub struct DevourFlakeInput {
 }
 
 /// Output of `devour-flake`
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DevourFlakeOutput {
     /// The built store paths
     ///

--- a/crates/nixci/src/step/build.rs
+++ b/crates/nixci/src/step/build.rs
@@ -1,6 +1,4 @@
 //! The build step
-use std::{collections::HashMap, path::PathBuf};
-
 use clap::Parser;
 use colored::Colorize;
 use nix_rs::{command::NixCmd, flake::url::FlakeUrl, store::command::NixStoreCmd};
@@ -53,25 +51,18 @@ impl BuildStep {
         let output =
             nix::devour_flake::devour_flake(nixcmd, verbose, devour_input, nix_args).await?;
 
-        let mut res = BuildStepResult::default();
-
-        res.by_name = output
-            .by_name
-            .into_iter()
-            .map(|(k, v)| (k, v.as_path().clone()))
-            .collect();
+        let mut res = BuildStepResult {
+            devour_flake_output: output,
+        };
 
         if run_cmd.steps_args.build_step_args.print_all_dependencies {
             // Handle --print-all-dependencies
-            let all_paths = NixStoreCmd.fetch_all_deps(output.out_paths).await?;
-            res.out_paths = all_paths.iter().map(Into::into).collect();
-        } else {
-            res.out_paths = output
-                .out_paths
-                .into_iter()
-                .map(|s| s.as_path().clone())
-                .collect();
-        };
+            let all_paths = NixStoreCmd
+                .fetch_all_deps(res.devour_flake_output.out_paths)
+                .await?;
+            let v = all_paths.into_iter().collect();
+            res.devour_flake_output.out_paths = v;
+        }
 
         Ok(res)
     }
@@ -142,19 +133,16 @@ impl BuildStepArgs {
 /// The result of the build step
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BuildStepResult {
-    /// The built store paths
-    ///
-    /// This includes all dependencies if --print-all-dependencies was passed.
-    pub out_paths: Vec<PathBuf>,
-
-    pub by_name: HashMap<String, PathBuf>,
+    /// Output of devour-flake
+    #[serde(flatten)]
+    pub devour_flake_output: devour_flake::DevourFlakeOutput,
 }
 
 impl BuildStepResult {
     /// Print the result to stdout
     pub fn print(&self) {
-        for path in &self.out_paths {
-            println!("{}", path.display());
+        for path in &self.devour_flake_output.out_paths {
+            println!("{}", path.as_path().display());
         }
     }
 }

--- a/crates/nixci/src/step/build.rs
+++ b/crates/nixci/src/step/build.rs
@@ -141,8 +141,8 @@ pub struct BuildStepResult {
     #[serde(flatten)]
     pub devour_flake_output: devour_flake::DevourFlakeOutput,
 
-    /// All dependencies of the out paths
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// All dependencies of the out paths, if available
+    #[serde(skip_serializing_if = "Option::is_none", rename = "allDeps")]
     pub all_deps: Option<Vec<StorePath>>,
 }
 

--- a/crates/nixci/src/step/core.rs
+++ b/crates/nixci/src/step/core.rs
@@ -49,6 +49,7 @@ pub struct StepsArgs {
 #[derive(Debug, Serialize, Clone, Default)]
 pub struct StepsResult {
     /// [BuildStepResult]
+    #[serde(rename = "build")]
     pub build_step: Option<BuildStepResult>,
 }
 

--- a/crates/nixci/src/step/core.rs
+++ b/crates/nixci/src/step/core.rs
@@ -96,3 +96,12 @@ impl StepsArgs {
         self.build_step_args.to_cli_args()
     }
 }
+
+impl StepsResult {
+    /// Print the results of all steps
+    pub fn print(&self) {
+        if let Some(build) = &self.build_step {
+            build.print();
+        }
+    }
+}

--- a/crates/nixci/src/step/core.rs
+++ b/crates/nixci/src/step/core.rs
@@ -75,8 +75,6 @@ impl Steps {
                 .build_step
                 .run(cmd, verbose, run_cmd, url, subflake)
                 .await?;
-            // TODO: Support --json for structured output grouped by steps
-            // build_res.print();
             res.build_step = Some(build_res);
         }
 

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -8,11 +8,13 @@
   - Display Nix installer used (supports DetSys installer)
 - `om ci`
   - Support for remote builds over SSH (via `--on` option)
-  - Avoid running `nix-store` command multiple times (#224)
   - Support for CI steps
     - Run `nix flake check` on all subflakes (#200)
     - Ability to add a custom CI step. For example, to run arbitrary commands.
-  - Locally cache `github:nix-systems` (to avoid Github API rate limit)
+  - Add `--json` for JSON output
+  - Misc
+    - Avoid running `nix-store` command multiple times (#224)
+    - Locally cache `github:nix-systems` (to avoid Github API rate limit)
 
 ### Fixes
 

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     "devour-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1726105360,
-        "narHash": "sha256-T3HUQwZKpsszqcMx5ENLF7yn2Rs98Ji+5Mgw710dPEU=",
+        "lastModified": 1726278569,
+        "narHash": "sha256-Cvc84VzvvdmehafnaIPfdPylNWJcDmv79QQh/MH/4Qk=",
         "owner": "srid",
         "repo": "devour-flake",
-        "rev": "c0b39f41f29706867681ed5edbbf99172ecf576b",
+        "rev": "dfa55397b9c76ae85478b97e6e921c8efe60fc62",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,15 @@
     "devour-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1726278569,
+        "lastModified": 1726283167,
         "narHash": "sha256-Cvc84VzvvdmehafnaIPfdPylNWJcDmv79QQh/MH/4Qk=",
         "owner": "srid",
         "repo": "devour-flake",
-        "rev": "dfa55397b9c76ae85478b97e6e921c8efe60fc62",
+        "rev": "9b96d31a55be119df8496ec5b7369823deec8a1c",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "json",
         "repo": "devour-flake",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -54,15 +54,16 @@
     "devour-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1709858306,
-        "narHash": "sha256-Vey9n9hIlWiSAZ6CCTpkrL6jt4r2JvT2ik9wa2bjeC0=",
+        "lastModified": 1726105360,
+        "narHash": "sha256-T3HUQwZKpsszqcMx5ENLF7yn2Rs98Ji+5Mgw710dPEU=",
         "owner": "srid",
         "repo": "devour-flake",
-        "rev": "17b711b9deadbbc5629cb7d2b64cf86ae72af3fa",
+        "rev": "c0b39f41f29706867681ed5edbbf99172ecf576b",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "json",
         "repo": "devour-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     cachix-push.url = "github:juspay/cachix-push";
 
     # nixci
-    devour-flake.url = "github:srid/devour-flake/json";
+    devour-flake.url = "github:srid/devour-flake";
     devour-flake.flake = false;
     nix-systems-x86_64-darwin.url = "github:nix-systems/x86_64-darwin";
     nix-systems-aarch64-darwin.url = "github:nix-systems/aarch64-darwin";

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     cachix-push.url = "github:juspay/cachix-push";
 
     # nixci
-    devour-flake.url = "github:srid/devour-flake";
+    devour-flake.url = "github:srid/devour-flake/json";
     devour-flake.flake = false;
     nix-systems-x86_64-darwin.url = "github:nix-systems/x86_64-darwin";
     nix-systems-aarch64-darwin.url = "github:nix-systems/aarch64-darwin";


### PR DESCRIPTION
`om ci run --json` will now print results in a structured format.

```
❯ cargo run -- ci run --json github:srid/nixos-config 2> /dev/null | jq
```

outputs:

```json
{
  "<root>": {
    "build": {
      "outPaths": [
        "/nix/store/ajbzmsnjm4s5bivcsmmpgnfrqbmkfj56-darwin-system-24.11.20240821.c374d94+darwin4.ea319a7",
        "/nix/store/6gpvaq76lrwqhkgnwmdf55mvb4pckh65-treefmt-check",
        "/nix/store/iwjcg0n5j5qygbxvzj89jhfn8kigdilg-nixos-config-shell",
        "/nix/store/d9xbi4rs1nfrcy1scn1i6ghbgbf28vwh-home-manager-generation",
        "/nix/store/91rxfs6058jq4dyx6m9ax1aa6r2m04s6-activate",
        "/nix/store/91rxfs6058jq4dyx6m9ax1aa6r2m04s6-activate",
        "/nix/store/pg1iap0zphzw3apb48r9iddhawl2diar-update-main-flake-inputs"
      ],
      "byName": {
        "darwin-system-24.11.20240821.c374d94+darwin4.ea319a7": "/nix/store/ajbzmsnjm4s5bivcsmmpgnfrqbmkfj56-darwin-system-24.11.20240821.c374d94+darwin4.ea319a7",
        "nixos-config-shell": "/nix/store/iwjcg0n5j5qygbxvzj89jhfn8kigdilg-nixos-config-shell",
        "activate": "/nix/store/91rxfs6058jq4dyx6m9ax1aa6r2m04s6-activate",
        "home-manager-generation": "/nix/store/d9xbi4rs1nfrcy1scn1i6ghbgbf28vwh-home-manager-generation",
        "treefmt-check": "/nix/store/6gpvaq76lrwqhkgnwmdf55mvb4pckh65-treefmt-check",
        "update-main-flake-inputs": "/nix/store/pg1iap0zphzw3apb48r9iddhawl2diar-update-main-flake-inputs"
      }
    }
  }
}
```

This can be used to get certain built paths, like dockerImage.