### PR TITLE
`om ci run`: Rename to `--results`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
             run \
               --systems "${{ matrix.system }}" \
-              --write-results=$HOME/omci.json
+              --results=$HOME/omci.json
 
       - name: Omnix results
         id: omci

--- a/crates/nixci/src/command/run.rs
+++ b/crates/nixci/src/command/run.rs
@@ -41,7 +41,7 @@ pub struct RunCommand {
 
     /// Path to write the results of the CI run (in JSON) to
     #[arg(long, short = 'o')]
-    pub write_results: Option<PathBuf>,
+    pub results: Option<PathBuf>,
 
     /// Flake URL or github URL
     ///
@@ -107,7 +107,7 @@ impl RunCommand {
         );
         let res = ci_run(nixcmd, verbose, self, &cfg, &nix_info.nix_config).await?;
 
-        if let Some(results_file) = self.write_results.as_ref() {
+        if let Some(results_file) = self.results.as_ref() {
             serde_json::to_writer(std::fs::File::create(results_file)?, &res)?;
             tracing::info!(
                 "Results written to {}",

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -11,7 +11,7 @@
   - Support for CI steps
     - Run `nix flake check` on all subflakes (#200)
     - Ability to add a custom CI step. For example, to run arbitrary commands.
-  - Add `--write-results=FILE` to store CI results as JSON in a file
+  - Add `--results=FILE` to store CI results as JSON in a file
   - Misc
     - Avoid running `nix-store` command multiple times (#224)
     - Locally cache `github:nix-systems` (to avoid Github API rate limit)


### PR DESCRIPTION
To be consistent with the upcoming `om ci get` command.