### PR TITLE
nix_rs(nix run): Append `FlakeOptions` after `run` subcommand

### DIFF
--- a/crates/nix_rs/src/flake/command.rs
+++ b/crates/nix_rs/src/flake/command.rs
@@ -21,8 +21,9 @@ pub async fn run(
 ) -> Result<(), CommandError> {
     nixcmd
         .run_with(|cmd| {
+            cmd.args(["run".to_string()]);
             opts.use_in_command(cmd);
-            cmd.args(["run".to_string(), url.to_string(), "--".to_string()]);
+            cmd.args([url.to_string(), "--".to_string()]);
             cmd.args(args);
         })
         .await


### PR DESCRIPTION
`--override-input` is unrecognised if used before, see:
```
❯ nix --override-input services-flake .. run .#cz-check
error: unrecognised flag '--override-input'
```