### PR TITLE
`om init` - Display flake URL alongside names

### DIFF
--- a/crates/omnix-init/src/config.rs
+++ b/crates/omnix-init/src/config.rs
@@ -23,9 +23,17 @@ impl<'a> Display for FlakeTemplate<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{:<15} {}",
+            "{:<15} {} {}",
             self.template_name,
-            format!("[{}]", self.flake).dimmed()
+            format!("[{}]", self.flake).dimmed(),
+            format!(
+                "{}",
+                self.template
+                    .template
+                    .description
+                    .as_ref()
+                    .unwrap_or(&"".to_string())
+            )
         )
     }
 }

--- a/crates/omnix-init/src/config.rs
+++ b/crates/omnix-init/src/config.rs
@@ -1,5 +1,9 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+};
 
+use colored::Colorize;
 use nix_rs::{
     command::NixCmd,
     flake::{command::FlakeOptions, eval::nix_eval, url::FlakeUrl},
@@ -7,16 +11,42 @@ use nix_rs::{
 
 use crate::template::Template;
 
-/// The `om.templates` config in flake
-pub type TemplatesConfig = HashMap<String, Template>;
+/// A named [Template] associated with a [FlakeUrl]
+#[derive(Debug, Clone)]
+pub(crate) struct FlakeTemplate<'a> {
+    pub(crate) flake: &'a FlakeUrl,
+    pub(crate) template_name: String,
+    pub(crate) template: Template,
+}
+
+impl<'a> Display for FlakeTemplate<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:<15} {}",
+            self.template_name,
+            format!("[{}]", self.flake).dimmed()
+        )
+    }
+}
 
 /// Load templates from the given flake
-pub async fn load_templates(url: &FlakeUrl) -> anyhow::Result<TemplatesConfig> {
+pub(crate) async fn load_templates<'a>(url: &FlakeUrl) -> anyhow::Result<Vec<FlakeTemplate>> {
     let opts = FlakeOptions {
         refresh: true,
         ..Default::default()
     };
-    let v = nix_eval::<TemplatesConfig>(&NixCmd::default(), &opts, &url.with_attr("om.templates"))
-        .await?;
-    Ok(v)
+    let v = nix_eval::<HashMap<String, Template>>(
+        &NixCmd::default(),
+        &opts,
+        &url.with_attr("om.templates"),
+    )
+    .await?;
+    Ok(v.into_iter()
+        .map(|(k, v)| FlakeTemplate {
+            flake: url,
+            template_name: k,
+            template: v,
+        })
+        .collect())
 }

--- a/crates/omnix-init/src/config.rs
+++ b/crates/omnix-init/src/config.rs
@@ -26,14 +26,11 @@ impl<'a> Display for FlakeTemplate<'a> {
             "{:<15} {} {}",
             self.template_name,
             format!("[{}]", self.flake).dimmed(),
-            format!(
-                "{}",
-                self.template
-                    .template
-                    .description
-                    .as_ref()
-                    .unwrap_or(&"".to_string())
-            )
+            self.template
+                .template
+                .description
+                .as_ref()
+                .unwrap_or(&"".to_string())
         )
     }
 }

--- a/crates/omnix-init/src/core.rs
+++ b/crates/omnix-init/src/core.rs
@@ -40,10 +40,9 @@ pub async fn initialize_template(
     let templates = load_templates(&flake).await?;
 
     // Prompt the user to select a template
-    // let available: Vec<String> = templates.keys().cloned().collect();
-    let available: Vec<AssocTemplate> = templates
+    let available: Vec<FlakeTemplate> = templates
         .iter()
-        .map(|(k, v)| AssocTemplate {
+        .map(|(k, v)| FlakeTemplate {
             flake: &flake,
             template_name: k.as_str(),
             template: v,
@@ -106,15 +105,15 @@ pub async fn initialize_template(
     Ok(())
 }
 
-/// A template associated with a flake
+/// A named [Template] associated with a [FlakeUrl]
 #[derive(Debug, Clone)]
-struct AssocTemplate<'a> {
+struct FlakeTemplate<'a> {
     flake: &'a FlakeUrl,
     template_name: &'a str,
     template: &'a Template,
 }
 
-impl<'a> Display for AssocTemplate<'a> {
+impl<'a> Display for FlakeTemplate<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,


### PR DESCRIPTION
This is to disambiguate when template names are as bare as `all` or `darwin` (as with upcoming nix-dev-home)

<img width="1064" alt="image" src="https://github.com/user-attachments/assets/4a253593-b41c-47aa-926d-923b7fc83805">

