### PR TITLE
`om init` Upstream test spec to individual flakes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,8 @@ name = "omnix-init"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_fs",
+ "assert_matches",
  "colored",
  "console",
  "globset",

--- a/crates/omnix-cli/src/command/init.rs
+++ b/crates/omnix-cli/src/command/init.rs
@@ -8,12 +8,18 @@ use serde_json::Value;
 #[derive(Parser, Debug)]
 pub struct InitCommand {
     /// Where to create the template
-    #[arg(short = 'o', long = "output")]
-    path: PathBuf,
+    #[arg(
+        name = "OUTPUT_DIR",
+        short = 'o',
+        long = "output",
+        required_unless_present = "test"
+    )]
+    path: Option<PathBuf>,
 
     /// The flake from which to initialize the template to use
     ///
     /// Defaults to builtin registry of flake templates.
+    #[arg(name = "FLAKE_URL")]
     flake: Option<FlakeUrl>,
 
     /// Parameter values to use for the template by default.
@@ -23,17 +29,36 @@ pub struct InitCommand {
     /// Whether to disable all prompting, making the command non-interactive
     #[arg(long = "non-interactive")]
     non_interactive: bool,
+
+    /// Run template tests, instead of initializing the template
+    #[arg(
+        long = "test",
+        requires = "FLAKE_URL",
+        conflicts_with = "non_interactive",
+        conflicts_with = "params",
+        conflicts_with = "OUTPUT_DIR"
+    )]
+    test: bool,
 }
 
 impl InitCommand {
     pub async fn run(&self) -> anyhow::Result<()> {
-        omnix_init::core::initialize_template(
-            &self.path,
-            self.flake.clone(),
-            &self.params.clone().unwrap_or_default().0,
-            self.non_interactive,
-        )
-        .await
+        // Prompt from builtin registry if the user has not specified one.
+        let flake = match self.flake {
+            Some(ref flake) => flake,
+            None => &omnix_init::core::select_from_registry().await?,
+        };
+        if self.test {
+            omnix_init::core::run_tests(flake).await?;
+        } else {
+            let path = self.path.as_ref().unwrap(); // unwrap is okay, because of `required_unless_present`
+            let params = self
+                .params
+                .as_ref()
+                .map_or_else(HashMap::new, |hm| hm.0.clone());
+            omnix_init::core::run(path, flake, &params, self.non_interactive).await?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/omnix-cli/tests/command/init.rs
+++ b/crates/omnix-cli/tests/command/init.rs
@@ -1,164 +1,22 @@
-use std::{collections::HashMap, path::Path};
-
-use crate::command::core::om;
-use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 use omnix_init::registry::BUILTIN_REGISTRY;
 
 /// `om init` runs and successfully initializes a template
 #[tokio::test]
 async fn om_init() -> anyhow::Result<()> {
-    for test in om_init_tests() {
-        test.run_test().await?;
+    let registry = BUILTIN_REGISTRY.clone();
+    for url in registry.0.values() {
+        println!("🕍 Testing template: {}", url);
+        let templates = omnix_init::config::load_templates(url).await?;
+        for template in templates {
+            let tests = &template.template.tests;
+            for (name, test) in tests {
+                println!(
+                    "🧪 [{}#{}] Running test: {}",
+                    url, template.template_name, name
+                );
+                test.run_test(name, &template).await?;
+            }
+        }
     }
     Ok(())
-}
-
-fn om_init_tests() -> Vec<OmInitTest> {
-    let registry = BUILTIN_REGISTRY.clone();
-    let lookup = |name: &str| registry.0.get(name).cloned().unwrap();
-    vec![
-        OmInitTest {
-            template_name: lookup("haskell-template"),
-            params: r#"{"package-name": "foo", "author": "John", "vscode": false }"#,
-            asserts: Asserts {
-                source: PathAsserts(HashMap::from([
-                    (".github/workflows/ci.yaml", true),
-                    (".vscode", false),
-                ])),
-                packages: HashMap::from([(
-                    "default".to_string(),
-                    PathAsserts(HashMap::from([("bin/foo", true)])),
-                )]),
-            },
-        },
-        OmInitTest {
-            template_name: lookup("rust-nix-template"),
-            params: r#"{"package-name": "qux", "author": "John", "author-email": "john@example.com" }"#,
-            asserts: Asserts {
-                source: PathAsserts(HashMap::from([
-                    ("Cargo.toml", true),
-                    ("flake.nix", true),
-                    (".github/workflows/ci.yml", true),
-                    (".vscode", true),
-                    ("nix/modules/template.nix", false),
-                ])),
-                packages: HashMap::from([(
-                    "default".to_string(),
-                    PathAsserts(HashMap::from([("bin/qux", true)])),
-                )]),
-            },
-        },
-        OmInitTest {
-            template_name: lookup("nixos-unified-template").with_attr("home"),
-            params: r#"{"username": "john", "git-email": "jon@ex.com", "git-name": "John", "neovim": true }"#,
-            asserts: Asserts {
-                source: PathAsserts(HashMap::from([
-                    ("modules/home/neovim/default.nix", true),
-                    (".github/workflows", false),
-                ])),
-                packages: HashMap::from([(
-                    "homeConfigurations.john.activationPackage".to_string(),
-                    PathAsserts(HashMap::from([
-                        ("home-path/bin/nvim", true),
-                        ("home-path/bin/vim", false),
-                    ])),
-                )]),
-            },
-        },
-    ]
-}
-
-/// A test for a single template
-struct OmInitTest {
-    /// The template name to pass to `om init`
-    template_name: FlakeUrl,
-    /// The --default-params to pass to `om init`
-    params: &'static str,
-    /// Various assertions to make after running `om init`
-    asserts: Asserts,
-}
-
-impl OmInitTest {
-    /// Run this test on a temporary directory
-    async fn run_test(&self) -> anyhow::Result<()> {
-        let temp_dir = assert_fs::TempDir::new().unwrap();
-        om()?
-            .args([
-                "init",
-                "-o",
-                &temp_dir.to_string_lossy(),
-                &self.template_name,
-                "--non-interactive",
-                "--params",
-                self.params,
-            ])
-            .assert()
-            .success();
-
-        // Recursively print the contents of temp_dir to debug test failures
-        let paths = omnix_common::fs::find_paths(&temp_dir).await?;
-        println!(
-            "[{}] Paths in temp_dir {}:",
-            self.template_name,
-            temp_dir.path().display()
-        );
-        for path in paths {
-            println!("  {}", path.display());
-        }
-
-        // Run assertion tests
-        self.asserts.assert(&temp_dir).await?;
-
-        temp_dir.close().unwrap();
-        Ok(())
-    }
-}
-
-#[derive(Default)]
-struct Asserts {
-    /// [PathAsserts] for the source directory
-    source: PathAsserts,
-    /// [PathAsserts] for `nix build .#<name>`'s out path
-    packages: HashMap<String, PathAsserts>,
-}
-
-impl Asserts {
-    async fn assert(&self, dir: &Path) -> anyhow::Result<()> {
-        self.source.assert(dir);
-
-        for (attr, package) in self.packages.iter() {
-            let paths = nix_rs::flake::command::build(
-                &NixCmd::default(),
-                FlakeUrl::from(dir).with_attr(attr),
-            )
-            .await?;
-            assert_matches!(paths.first().and_then(|v| v.first_output()), Some(path) => {
-                package.assert(path);
-            });
-        }
-
-        Ok(())
-    }
-}
-
-/// Set of path assertions to make
-///
-/// If value is true, the path must exist.
-#[derive(Default)]
-struct PathAsserts(HashMap<&'static str, bool>);
-
-impl PathAsserts {
-    fn assert(&self, dir: &Path) {
-        for (path, must_exist) in self.0.iter() {
-            let check = dir.join(path).exists();
-            let verb = if *must_exist { "exist" } else { "not exist" };
-            assert!(
-                if *must_exist { check } else { !check },
-                "Expected path to {}: {:?} (under {:?})",
-                verb,
-                path,
-                dir,
-            );
-        }
-    }
 }

--- a/crates/omnix-cli/tests/test.rs
+++ b/crates/omnix-cli/tests/test.rs
@@ -1,3 +1,2 @@
-#[macro_use]
 extern crate assert_matches;
 mod command;

--- a/crates/omnix-init/Cargo.toml
+++ b/crates/omnix-init/Cargo.toml
@@ -15,6 +15,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = { workspace = true }
+assert_fs = "1"
+assert_matches = "1.5"
 colored = { workspace = true }
 console = { workspace = true }
 globset = { workspace = true }

--- a/crates/omnix-init/src/config.rs
+++ b/crates/omnix-init/src/config.rs
@@ -11,12 +11,13 @@ use crate::template::Template;
 
 /// A named [Template] associated with a [FlakeUrl]
 #[derive(Debug, Clone)]
-pub(crate) struct FlakeTemplate<'a> {
-    pub(crate) flake: &'a FlakeUrl,
-    pub(crate) template_name: String,
-    pub(crate) template: Template,
+pub struct FlakeTemplate<'a> {
+    pub flake: &'a FlakeUrl,
+    pub template_name: String,
+    pub template: Template,
 }
 
+// This instance is used during user prompting.
 impl<'a> Display for FlakeTemplate<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
@@ -34,7 +35,7 @@ impl<'a> Display for FlakeTemplate<'a> {
 }
 
 /// Load templates from the given flake
-pub(crate) async fn load_templates<'a>(url: &FlakeUrl) -> anyhow::Result<Vec<FlakeTemplate>> {
+pub async fn load_templates<'a>(url: &FlakeUrl) -> anyhow::Result<Vec<FlakeTemplate>> {
     let _opts = FlakeOptions {
         refresh: true,
         ..Default::default()

--- a/crates/omnix-init/src/core.rs
+++ b/crates/omnix-init/src/core.rs
@@ -1,9 +1,33 @@
 use std::{collections::HashMap, path::Path};
 
-use crate::{config::load_templates, template::Template};
+use crate::config::{load_templates, FlakeTemplate};
 use anyhow::Context;
 use nix_rs::flake::url::FlakeUrl;
 use serde_json::Value;
+
+pub async fn select_from_registry() -> anyhow::Result<FlakeUrl> {
+    let builtin_registry = crate::registry::BUILTIN_REGISTRY.clone();
+    // Prompt the user to select a flake from the registry
+    let available: Vec<String> = builtin_registry.0.keys().cloned().collect();
+    let name = inquire::Select::new("Select a flake", available).prompt()?;
+    builtin_registry
+        .0
+        .get(&name)
+        .cloned()
+        .ok_or(anyhow::anyhow!("Flake not found in builtin registry"))
+}
+
+pub async fn run_tests(flake: &FlakeUrl) -> anyhow::Result<()> {
+    let templates = load_templates(flake).await?;
+    for template in templates.iter() {
+        tracing::info!("Testing template: {}", template.template_name);
+        for (name, test) in template.template.tests.iter() {
+            tracing::info!("Running test: {}", name);
+            test.run_test(name, template).await?;
+        }
+    }
+    Ok(())
+}
 
 /// Initialize a template at the given path
 ///
@@ -12,34 +36,19 @@ use serde_json::Value;
 /// - `name` - The name of the template to initialize
 /// - `default_params` - The default parameter values to use
 /// - `non_interactive` - Whether to disable user prompts (all params must have values set)
-pub async fn initialize_template(
+pub async fn run(
     path: &Path,
-    m_flake: Option<FlakeUrl>,
+    flake: &FlakeUrl,
     default_params: &HashMap<String, Value>,
     non_interactive: bool,
 ) -> anyhow::Result<()> {
-    let flake: FlakeUrl = match m_flake {
-        Some(flake) => Ok(flake),
-        None => {
-            let builtin_registry = crate::registry::BUILTIN_REGISTRY.clone();
-            // Prompt the user to select a flake from the registry
-            let available: Vec<String> = builtin_registry.0.keys().cloned().collect();
-            let name = inquire::Select::new("Select a flake", available).prompt()?;
-            builtin_registry
-                .0
-                .get(&name)
-                .cloned()
-                .ok_or(anyhow::anyhow!("Flake not found in builtin registry"))
-        }
-    }?;
-    let templates = load_templates(&flake).await?;
-
+    let templates = load_templates(flake).await?;
     // Prompt the user to select a template
-    let mut template: Template = if let Some(attr) = flake.get_attr().0 {
+    let mut template: FlakeTemplate = if let Some(attr) = flake.get_attr().0 {
         templates
             .iter()
             .find(|t| t.template_name == attr)
-            .map(|t| t.template.clone())
+            .cloned()
             .with_context(|| "Template not found")?
     } else if templates.len() < 2 {
         if let Some(first) = templates.first() {
@@ -47,23 +56,23 @@ pub async fn initialize_template(
                 "Automatically choosing the one template available: {}",
                 first.template_name
             );
-            first.template.clone()
+            first.clone()
         } else {
             return Err(anyhow::anyhow!("No templates available"));
         }
     } else if non_interactive {
         return Err(
-            anyhow::anyhow!("Non-interactive mode requires exactly one template to be available; but {} are available. Explicit specify it in flake URL.",
-            templates.len()));
+              anyhow::anyhow!("Non-interactive mode requires exactly one template to be available; but {} are available. Explicit specify it in flake URL.",
+              templates.len()));
     } else {
         let select = inquire::Select::new("Select a template", templates);
-        select.prompt()?.template.clone()
+        select.prompt()?.clone()
     };
 
-    template.set_param_values(default_params);
+    template.template.set_param_values(default_params);
 
     if non_interactive {
-        for param in template.params.iter() {
+        for param in template.template.params.iter() {
             if !param.action.has_value() {
                 return Err(anyhow::anyhow!(
                     "Non-interactive mode requires all parameters to be set; but {} is missing",
@@ -72,19 +81,25 @@ pub async fn initialize_template(
             }
         }
     } else {
-        for param in template.params.iter_mut() {
+        for param in template.template.params.iter_mut() {
             param.set_value_by_prompting()?;
         }
     }
 
+    initialize_template(path, &template).await?;
+    Ok(())
+}
+
+async fn initialize_template<'a>(path: &Path, template: &FlakeTemplate<'a>) -> anyhow::Result<()> {
     tracing::info!("Initializing template at {}", path.display());
     template
+        .template
         .scaffold_at(path)
         .await
         .with_context(|| "Unable to scaffold")?;
     tracing::info!("🥳 Initialized template at {}", path.display());
 
-    if let Some(welcome_text) = template.template.welcome_text {
+    if let Some(welcome_text) = template.template.template.welcome_text.as_ref() {
         let skin = termimad::MadSkin::default();
         eprint!(
             "\n{}",

--- a/crates/omnix-init/src/lib.rs
+++ b/crates/omnix-init/src/lib.rs
@@ -1,6 +1,9 @@
+#[macro_use]
+extern crate assert_matches;
 pub mod action;
 pub mod config;
 pub mod core;
 pub mod param;
 pub mod registry;
 pub mod template;
+pub mod test;

--- a/crates/omnix-init/src/template.rs
+++ b/crates/omnix-init/src/template.rs
@@ -15,6 +15,8 @@ use crate::param;
 pub struct Template {
     pub template: NixTemplate,
     pub params: Vec<param::Param>,
+    #[serde(default)]
+    pub tests: HashMap<String, super::test::OmInitTest>,
 }
 
 /// The official Nix template (`flake.templates.<name>`)

--- a/crates/omnix-init/src/test.rs
+++ b/crates/omnix-init/src/test.rs
@@ -1,0 +1,106 @@
+use std::{collections::HashMap, path::Path};
+
+use anyhow::Context;
+use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::config::FlakeTemplate;
+
+/// A test for a single template
+#[derive(Debug, Deserialize, Clone)]
+pub struct OmInitTest {
+    /// The template name to pass to `om init`
+    /// MAKES NO SENSE
+    /// template_name: FlakeUrl,
+    /// The --default-params to pass to `om init`
+    params: HashMap<String, Value>,
+    /// Various assertions to make after running `om init`
+    asserts: Asserts,
+}
+
+impl OmInitTest {
+    /// Run this test on a temporary directory
+    pub async fn run_test<'a>(
+        &self,
+        _name: &str,
+        template: &FlakeTemplate<'a>,
+    ) -> anyhow::Result<()> {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let mut template = template.clone();
+        template.template.set_param_values(&self.params);
+        template
+            .template
+            .scaffold_at(&temp_dir)
+            .await
+            .with_context(|| "Unable to scaffold")?;
+
+        // Recursively print the contents of temp_dir to debug test failures
+        let paths = omnix_common::fs::find_paths(&temp_dir).await?;
+        println!(
+            "Paths in temp_dir {}: {}",
+            temp_dir.path().display(),
+            paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+
+        // Run assertion tests
+        self.asserts.assert(&temp_dir).await?;
+
+        temp_dir.close().unwrap();
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct Asserts {
+    /// [PathAsserts] for the source directory
+    source: PathAsserts,
+    /// [PathAsserts] for `nix build .#<name>`'s out path
+    packages: HashMap<String, PathAsserts>,
+}
+
+impl Asserts {
+    async fn assert(&self, dir: &Path) -> anyhow::Result<()> {
+        self.source.assert(dir);
+
+        for (attr, package) in self.packages.iter() {
+            let paths = nix_rs::flake::command::build(
+                &NixCmd::default(),
+                FlakeUrl::from(dir).with_attr(attr),
+            )
+            .await?;
+            assert_matches!(paths.first().and_then(|v| v.first_output()), Some(path) => {
+                package.assert(path);
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Set of path assertions to make
+///
+/// If value is true, the path must exist.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct PathAsserts(HashMap<String, bool>);
+
+impl PathAsserts {
+    fn assert(&self, dir: &Path) {
+        for (path, must_exist) in self.0.iter() {
+            println!("PathAssert {}; exist? ({}) in {:?}", path, must_exist, dir);
+            let check = dir.join(path).exists();
+            let verb = if *must_exist { "exist" } else { "not exist" };
+            assert!(
+                if *must_exist { check } else { !check },
+                "Expected path to {}: {:?} (under {:?})",
+                verb,
+                path,
+                dir,
+            );
+        }
+    }
+}

--- a/doc/src/om/init.md
+++ b/doc/src/om/init.md
@@ -71,3 +71,34 @@ Here, when prompting for this param, the user-provided value if any will replace
 Here, if the user enables this param, the path globs specified in `paths` will be retained in the template. Otherwise, the paths will be deleted. The `value` key provides a default value; which key is supported for string params as well.
 
 Both parameter types are distinguished by the presence of the relevant keys (`placeholder` for string, `paths` for boolean).
+
+## Testing templates {#test}
+
+The configuration can also include a `tests` key that defines a list of tests to run on the template. Each test is an attrset with `params` and `asserts` keys that indicates the parameter values to test along with the path existance assertions. [For example](https://github.com/juspay/nixos-unified-template/blob/3c4428ac94a4582a33e6fb3fe18df27bbc1e9eb7/modules/flake-parts/template.nix#L139-L157):
+
+```nix
+{
+  tests = {
+    default = {
+      params = {
+        username = "john";
+        git-email = "john@ex.com";
+        git-name = "John Doe";
+        neovim = true;
+      };
+      asserts = {
+        # Path assertion tests under template output
+        source = {
+          # true means the path must exist; false means it must not exist
+          "modules/home/neovim/default.nix" = true;
+          ".github/workflows" = false;
+        };
+        # Path assertion tests under the output of a Nix package
+        packages."homeConfigurations.john.activationPackage" = {
+          "home-path/bin/nvim" = true;
+        };
+      };
+    };
+  };
+}
+```


### PR DESCRIPTION
Template tests can now be defined alongside the flake that defines the template. 

For example, https://github.com/juspay/nixos-unified-template/blob/3c4428ac94a4582a33e6fb3fe18df27bbc1e9eb7/modules/flake-parts/template.nix#L139-L157

<img width="458" alt="image" src="https://github.com/user-attachments/assets/386b1a6c-7576-43d4-883a-038df0c40380">

To run them, `om init --test <url>`.