### PR TITLE
Optimize CI times

### DIFF
--- a/crates/nix_rs/src/system_list.rs
+++ b/crates/nix_rs/src/system_list.rs
@@ -89,19 +89,3 @@ where
         .await?;
     Ok(v)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_empty_systems_list() {
-        let systems = SystemsList::from_flake(
-            &NixCmd::default(),
-            &SystemsListFlakeRef(FlakeUrl("github:nix-systems/empty".to_string())),
-        )
-        .await
-        .unwrap();
-        assert_eq!(systems.0, vec![]);
-    }
-}

--- a/crates/nixci/crate.nix
+++ b/crates/nixci/crate.nix
@@ -39,16 +39,9 @@ in
         ;
       DEVOUR_FLAKE = inputs.devour-flake;
 
-      # To avoid unnecessary rebuilds, start from cleaned source, and then add the Nix files necessary to `nix run` it. Finally, add any files required by the Rust build.
-      OMNIX_SOURCE = lib.cleanSourceWith {
-        src = inputs.self;
-        filter = path: type:
-          rust-project.crane-lib.filterCargoSources path type
-          || lib.hasSuffix ".nix" path
-          || lib.hasSuffix "flake.lock" path
-          || lib.hasSuffix "registry.json" path
-        ;
-      };
+      # This value is set in omnix-cli/crate.nix.
+      # We use a dummy value here, however, to avoid unnecessarily rebuilding nixci in CI
+      OMNIX_SOURCE = pkgs.hello;
     };
   };
 }

--- a/crates/omnix-cli/tests/command/init.rs
+++ b/crates/omnix-cli/tests/command/init.rs
@@ -9,6 +9,7 @@ async fn om_init() -> anyhow::Result<()> {
     let current_system = &cfg.system.value;
     for url in registry.0.values() {
         // TODO: Refactor(DRY) with src/core.rs:run_tests
+        // TODO: Make this test (and other tests) use tracing!
         println!("🕍 Testing template: {}", url);
         let templates = omnix_init::config::load_templates(url).await?;
         for template in templates {


### PR DESCRIPTION
`nixci-deps` has been rebuilding all this time. This PR makes it build only when nixci itself changes. The trick is to move `OMNIX_SOURCE` build dep to `omnix-cli`.

In future, we want to figure out a better to avoid build-depending on the source tree, especially after upstreaming omnix to nixpkgs.