### PR TITLE
init: Make registry pure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
  "globset",
  "inquire",
  "itertools",
+ "lazy_static",
  "nix_rs",
  "omnix-common",
  "serde",

--- a/crates/omnix-cli/tests/command/init.rs
+++ b/crates/omnix-cli/tests/command/init.rs
@@ -1,10 +1,9 @@
 use nix_rs::config::NixConfig;
-use omnix_init::registry::BUILTIN_REGISTRY;
 
 /// `om init` runs and successfully initializes a template
 #[tokio::test]
 async fn om_init() -> anyhow::Result<()> {
-    let registry = BUILTIN_REGISTRY.clone();
+    let registry = omnix_init::registry::get().await.as_ref()?;
     let cfg = NixConfig::get().await.as_ref()?;
     let current_system = &cfg.system.value;
     for url in registry.0.values() {

--- a/crates/omnix-init/Cargo.toml
+++ b/crates/omnix-init/Cargo.toml
@@ -22,6 +22,7 @@ console = { workspace = true }
 globset = { workspace = true }
 inquire = { workspace = true }
 itertools = { workspace = true }
+lazy_static = { workspace = true }
 nix_rs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/omnix-init/registry/flake.lock
+++ b/crates/omnix-init/registry/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "haskell-flake": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728227251,
+        "narHash": "sha256-JLDhMFyGyFe0QJAbCuSxB7/kjUCA7uUAMa6BFRORwXk=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "9cbfbfc38f1fbf9a0f471795c84780211875fd45",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "haskell-template": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728428876,
+        "narHash": "sha256-DJFBFzs9+45z/i53kqYge6L3kxzRok+d2JQcYjBWT50=",
+        "owner": "srid",
+        "repo": "haskell-template",
+        "rev": "c05c9977e04c0e09ae6b5e06ac2f2332c60dcad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-template",
+        "type": "github"
+      }
+    },
+    "nixos-unified-template": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728495100,
+        "narHash": "sha256-SHTeInt30t+pEPIpP4OSyf1iuofI4+BhOBTsKk2jQRw=",
+        "owner": "juspay",
+        "repo": "nixos-unified-template",
+        "rev": "f8ce617b401c3ca5d694931486599bcb28671037",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "nixos-unified-template",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "haskell-flake": "haskell-flake",
+        "haskell-template": "haskell-template",
+        "nixos-unified-template": "nixos-unified-template",
+        "rust-nix-template": "rust-nix-template"
+      }
+    },
+    "rust-nix-template": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728428985,
+        "narHash": "sha256-QSJyUpGjBsBnhvKPlpu5ZQZu8wlUtdk2sw8Wn/cyR/0=",
+        "owner": "srid",
+        "repo": "rust-nix-template",
+        "rev": "f1fea514816b0c9ed39fb19985726377ddcf32fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "rust-nix-template",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/crates/omnix-init/registry/flake.nix
+++ b/crates/omnix-init/registry/flake.nix
@@ -1,0 +1,26 @@
+# `om init` registry's canonical source
+#
+# Get JSON using:
+# nix eval --json .#registry | jq
+{
+  inputs = {
+    haskell-flake.url = "github:srid/haskell-flake";
+    haskell-flake.flake = false;
+
+    haskell-template.url = "github:srid/haskell-template";
+    haskell-template.flake = false;
+
+    rust-nix-template.url = "github:srid/rust-nix-template";
+    rust-nix-template.flake = false;
+
+    nixos-unified-template.url = "github:juspay/nixos-unified-template";
+    nixos-unified-template.flake = false;
+  };
+
+  outputs = inputs: {
+    registry =
+      builtins.mapAttrs
+        (k: v: v.outPath)
+        (builtins.removeAttrs inputs [ "self" ]);
+  };
+}

--- a/crates/omnix-init/registry/registry.json
+++ b/crates/omnix-init/registry/registry.json
@@ -1,6 +1,0 @@
-{
-  "haskell-flake": "github:srid/haskell-flake",
-  "haskell-template": "github:srid/haskell-template",
-  "rust-nix-template": "github:srid/rust-nix-template",
-  "nixos-unified-template": "github:juspay/nixos-unified-template"
-}

--- a/crates/omnix-init/src/core.rs
+++ b/crates/omnix-init/src/core.rs
@@ -6,7 +6,7 @@ use nix_rs::flake::{system::System, url::FlakeUrl};
 use serde_json::Value;
 
 pub async fn select_from_registry() -> anyhow::Result<FlakeUrl> {
-    let builtin_registry = crate::registry::BUILTIN_REGISTRY.clone();
+    let builtin_registry = crate::registry::get().await.as_ref()?;
     // Prompt the user to select a flake from the registry
     let available: Vec<String> = builtin_registry.0.keys().cloned().collect();
     let name = inquire::Select::new("Select a flake", available).prompt()?;

--- a/doc/src/om/init.md
+++ b/doc/src/om/init.md
@@ -15,13 +15,13 @@ This will prompt you to choose a template from the builtin registry (see below s
 
 ## Builtin registry {#registry}
 
-The builtin registry (stored in [a JSON file][json]) contains the following templates:
+The builtin registry (stored in [a flake][flake]) contains the following templates:
 
 - [Haskell project template](https://github.com/srid/haskell-template)
 - [Rust project template](https://github.com/srid/rust-nix-template)
 - [NixOS/ nix-darwin/ home-manager template](https://github.com/juspay/nixos-unified-template)
 
-[json]: https://github.com/juspay/omnix/blob/main/crates/omnix-init/registry/registry.json
+[flake]: https://github.com/juspay/omnix/blob/main/crates/omnix-init/registry/flake.nix
 
 ## Initializing your own project templates {#custom}
 

--- a/nix/modules/om.nix
+++ b/nix/modules/om.nix
@@ -34,6 +34,16 @@
         };
         doc.dir = "doc";
 
+        registry = {
+          dir = "crates/omnix-init/registry";
+          steps = {
+            build.enable = false;
+
+            # FIXME: Why does omnix require this?
+            custom = { };
+          };
+        };
+
         # Because the cargo tests invoking Nix doesn't pass github access tokens..
         # To avoid GitHub rate limits during the integration test (which
         # doesn't use the token)


### PR DESCRIPTION
The registry flakes are now locked in a flake.lock file.

Because we use flake=false, the lockfile is now manageable.

This should substantially reduce #304 