### PR TITLE
`om hack`: Multi-stage support for direct `direnv` integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,6 +3,7 @@ source ./omnixrc
 watch_file \
     ./omnixrc \
     nix/modules/flake-parts/nixpkgs.nix \
+    nix/modules/flake-parts/om.nix \
     nix/modules/flake-parts/rust.nix \
     nix/modules/flake-parts/devshell.nix \
     ./crates/*/crate.nix \

--- a/crates/omnix-cli/src/command/hack.rs
+++ b/crates/omnix-cli/src/command/hack.rs
@@ -8,11 +8,32 @@ pub struct HackCommand {
     /// Directory of the project
     #[arg(name = "DIR", default_value = ".")]
     dir: PathBuf,
+
+    // TODO: Implement these options
+    // om hack --mode-before
+    // om hack --mode-after-success
+    #[arg(long, value_enum)]
+    stage: Option<Stage>,
+}
+
+/// The stage to run in
+#[derive(clap::ValueEnum, Debug, Clone)]
+enum Stage {
+    /// Stage before Nix shell is invoked.
+    PreShell,
+
+    /// Stage after Nix shell is successfully invoked.
+    PostShell,
 }
 
 impl HackCommand {
     pub async fn run(&self) -> anyhow::Result<()> {
-        omnix_hack::core::hack_on(&self.dir).await?;
+        let prj = omnix_hack::core::Project::new(&self.dir).await?;
+        match self.stage {
+            Some(Stage::PreShell) => omnix_hack::core::hack_on_pre_shell(&prj).await?,
+            Some(Stage::PostShell) => omnix_hack::core::hack_on_post_shell(&prj).await?,
+            None => omnix_hack::core::hack_on(&prj).await?,
+        }
         Ok(())
     }
 }

--- a/crates/omnix-hack/src/config.rs
+++ b/crates/omnix-hack/src/config.rs
@@ -7,23 +7,13 @@ use crate::readme::Readme;
 
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct HackConfig {
-    pub cache: Option<CacheConfig>,
     pub readme: Readme,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct CacheConfig {
-    pub cachix: CachixConfig,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct CachixConfig {
-    /// Name of the cachix cache (`https://<name>.cachix.org`)
-    pub name: String,
-    /// The read-only auth token to use if this is a private cache
-    ///
-    /// If provided, will run `cachix authtoken <auth_token>`.
-    pub auth_token: Option<String>,
+    /// Cache substituter URL
+    pub url: String,
 }
 
 impl HackConfig {

--- a/crates/omnix-hack/src/core.rs
+++ b/crates/omnix-hack/src/core.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use nix_rs::{flake::url::FlakeUrl, info::NixInfo};
 use omnix_common::markdown::print_markdown;
@@ -7,15 +7,31 @@ use omnix_health::{traits::Checkable, NixHealth};
 
 use crate::config::HackConfig;
 
-pub async fn hack_on(dir: &Path) -> anyhow::Result<()> {
-    let dir = dir.canonicalize()?;
-    let here_flake: FlakeUrl = Into::<FlakeUrl>::into(dir.as_ref());
-    let cfg = HackConfig::from_flake(&here_flake).await?;
+pub struct Project {
+    pub dir: PathBuf,
+    pub flake: FlakeUrl,
+    pub cfg: HackConfig,
+}
 
-    // TODO: cachix check
+impl Project {
+    pub async fn new(dir: &Path) -> anyhow::Result<Self> {
+        let dir = dir.canonicalize()?;
+        let flake: FlakeUrl = Into::<FlakeUrl>::into(dir.as_ref());
+        let cfg = HackConfig::from_flake(&flake).await?;
+        Ok(Self { dir, flake, cfg })
+    }
+}
 
+pub async fn hack_on(prj: &Project) -> anyhow::Result<()> {
+    hack_on_pre_shell(prj).await?;
+    hack_on_post_shell(prj).await?;
+    Ok(())
+}
+
+pub async fn hack_on_pre_shell(prj: &Project) -> anyhow::Result<()> {
     // Run relevant `om health` checks
-    let health = NixHealth::from_flake(&here_flake).await?;
+    tracing::info!("om hack: Running pre-shell checks");
+    let health = NixHealth::from_flake(&prj.flake).await?;
     let nix_info = NixInfo::get()
         .await
         .as_ref()
@@ -29,7 +45,7 @@ pub async fn hack_on(dir: &Path) -> anyhow::Result<()> {
         &health.caches,
     ];
     for check_kind in relevant_checks.into_iter() {
-        for check in check_kind.check(nix_info, Some(&here_flake)) {
+        for check in check_kind.check(nix_info, Some(&prj.flake)) {
             if !check.result.green() {
                 check.tracing_log().await?;
                 if !check.result.green() && check.required {
@@ -42,10 +58,11 @@ pub async fn hack_on(dir: &Path) -> anyhow::Result<()> {
     if !health.caches.required.is_empty() {
         // TODO: Auto-resolve some problems; like running 'cachix use' automatically
     };
-    tracing::info!("Healthy");
+    Ok(())
+}
 
+pub async fn hack_on_post_shell(prj: &Project) -> anyhow::Result<()> {
     eprintln!();
-    print_markdown(&dir, &cfg.readme.get_markdown()).await?;
-
+    print_markdown(&prj.dir, &prj.cfg.readme.get_markdown()).await?;
     Ok(())
 }

--- a/crates/omnix-hack/src/readme.rs
+++ b/crates/omnix-hack/src/readme.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 // TODO(idea): What if we provide `om health` like checkmark for each item. Automatically check if the user is in Nix shell or direnv, and ✅ the title accordingly. If not, nudge them to do it.
 const OM_SHELL: &str = r#"## Enter the Nix shell
 
-We recommend that you setup nix-direnv (preferably using the convenient template is provided at <https://github.com/juspay/nixos-unified-template>). Then run the following in terminal to activate the Nix shell:
+We recommend that you setup nix-direnv (preferably using the convenient template provided at <https://github.com/juspay/nixos-unified-template>). Then run the following in terminal to activate the Nix shell:
 
 ```sh-session
 direnv allow

--- a/nix/modules/flake-parts/devshell.nix
+++ b/nix/modules/flake-parts/devshell.nix
@@ -12,7 +12,6 @@ in
       meta.description = "Omnix development environment";
       inputsFrom = [
         config.treefmt.build.devShell
-        config.nix-health.outputs.devShell
         self'.devShells.rust
       ];
       inherit (config.rust-project.crates."omnix-cli".crane.args)
@@ -38,12 +37,6 @@ in
         mdbook
         mdbook-alerts
       ];
-      shellHook =
-        ''
-          echo
-          echo "🍎🍎 Run 'just <recipe>' to get started"
-          just
-        '';
     };
   };
 }

--- a/nix/modules/flake-parts/om.nix
+++ b/nix/modules/flake-parts/om.nix
@@ -63,11 +63,6 @@
         direnv.required = true;
       };
       hack.default = {
-        # TODO: This is not implemented yet.
-        cache.cachix = {
-          name = "om";
-          # authToken = "xxx";
-        };
         readme = ''
           🍾 Welcome to the **omnix** project
 
@@ -75,21 +70,15 @@
 
           OM_IDE
 
-          ## Running `omnix` inside devShell
-
-          This will run `cargo watch` and run the resultant program, and then restart the same as you modify the Rust sources:
+          To run the project,
 
           ```sh-session
           just watch <args>
           ```
 
-          ## Running `omnix` through Nix
-          ```sh-session
-          nix --accept-flake-config run github:juspay/omnix
-          ```
+          (Now, as you edit the Rust sources, the above will reload!)
 
-          ## Read more
-          For details, see [README.md](README.md)
+          🍎🍎 Run 'just' to see more commands.
         '';
       };
     };

--- a/omnixrc
+++ b/omnixrc
@@ -4,8 +4,9 @@
 use_omnix() {
   # TODO: Switch to nixpkgs version once we upstream
   # Because, the user may not be a trusted-user leading to compilation!
-  nix --accept-flake-config run github:juspay/omnix health $*
+  nix --accept-flake-config run github:juspay/omnix hack $*
 
   # Use of --accept-flake-config ensures that configured cache is used to launch the devShell
+  # TODO: Run omnix readme step *after* this.
   use flake $* --accept-flake-config
 }

--- a/omnixrc
+++ b/omnixrc
@@ -9,4 +9,10 @@ use_omnix() {
   # Use of --accept-flake-config ensures that configured cache is used to launch the devShell
   # TODO: Run omnix readme step *after* this.
   use flake $* --accept-flake-config
+
+  if [[ ! -z "${NIX_DIRENV_DID_FALLBACK:-}" ]]; then
+      echo "Fallback"
+  else
+      echo "Done".
+  fi
 }

--- a/omnixrc
+++ b/omnixrc
@@ -4,15 +4,16 @@
 use_omnix() {
   # TODO: Switch to nixpkgs version once we upstream
   # Because, the user may not be a trusted-user leading to compilation!
-  nix --accept-flake-config run github:juspay/omnix hack $*
+  nix --accept-flake-config run github:juspay/omnix/om-hack-more -- hack --stage=pre-shell $*
 
   # Use of --accept-flake-config ensures that configured cache is used to launch the devShell
   # TODO: Run omnix readme step *after* this.
   use flake $* --accept-flake-config
 
   if [[ ! -z "${NIX_DIRENV_DID_FALLBACK:-}" ]]; then
-      echo "Fallback"
+    # Nix shell failed; move on!
+    echo
   else
-      echo "Done".
+    nix --accept-flake-config run github:juspay/omnix/om-hack-more -- hack --stage=post-shell $*
   fi
 }


### PR DESCRIPTION
Add two modes of running `om hack`:

1. `om hack --stage=pre-shell`: Run only health check, and (eventually) auto-resolve cachix use
2. `om hack --stage=post-shell`: Render om.hack.readme upon successful Nix shell entering

The typical direnv `use flake` happens in between (1) and (2). Notably, (2) only happens if the Nix shell succeeds. Thus, this gets rid of our `shellHook` echo'ing stuff as well.

---

In a future, I should add support for regular `nix develop` (non-direnv) support, so `om hack` should just drop one directly into a Nix shell.