### PR TITLE
`omnixrc`: Exit when omnix fails

### DIFF
--- a/crates/omnix-health/crate.nix
+++ b/crates/omnix-health/crate.nix
@@ -25,7 +25,7 @@ in
         INSPECT_FLAKE
         NIX_SYSTEMS
         ;
-      CACHIX_BIN = lib.getExe pkgs.cachix;
+      CACHIX_BIN = pkgs.cachix + /bin/cachix;
       nativeBuildInputs = with pkgs; [
         nix # Tests need nix cli
       ];

--- a/doc/src/om/index.md
+++ b/doc/src/om/index.md
@@ -1,4 +1,4 @@
 
 # The `om` CLI
 
-The Omnix CLI currently provides a fully-functioning [`health`](health.md) and [`ci`](ci.md) commands. The [`show`](show.md) command has basic functionality, whereas the [`init`](init.md) command is not yet ready for wider use.
+The Omnix CLI currently provides a fully-functioning [`health`](health.md) and [`ci`](ci.md) commands. The [`show`](show.md) command has basic functionality, whereas the [`init`](init.md) command can be used to scaffold new projects using Nix.

--- a/omnixrc
+++ b/omnixrc
@@ -8,7 +8,7 @@ use_omnix() {
     --accept-flake-config \
     --option builders '' \
     -j0 \
-    run github:juspay/omnix -- hack --stage=pre-shell $*
+    run github:juspay/omnix -- hack --stage=pre-shell $* || exit 1
 
   use flake ${*:-.} --accept-flake-config
 


### PR DESCRIPTION
Since not everyone will have direnv strict_env enabled.