### PR TITLE
nix: Restrict OMNIX_SOURCE further to avoid rebuilds

### DIFF
--- a/crates/omnix-cli/crate.nix
+++ b/crates/omnix-cli/crate.nix
@@ -50,16 +50,7 @@ in
         CACHIX_BIN
         ;
 
-      # To avoid unnecessary rebuilds, start from cleaned source, and then add the Nix files necessary to `nix run` it. Finally, add any files required by the Rust build.
-      OMNIX_SOURCE = lib.cleanSourceWith {
-        src = inputs.self;
-        filter = path: type:
-          rust-project.crane-lib.filterCargoSources path type
-            || lib.hasSuffix ".nix" path
-            || lib.hasSuffix "flake.lock" path
-            || lib.hasSuffix "registry.json" path
-        ;
-      };
+      OMNIX_SOURCE = rust-project.src;
 
       # Disable tests due to sandboxing issues; we run them on CI
       # instead.

--- a/nix/modules/flake-parts/om.nix
+++ b/nix/modules/flake-parts/om.nix
@@ -14,10 +14,6 @@
                 # name = "default";
                 args = [ "show" "." ];
               };
-              build-omnix-source = {
-                type = "app";
-                name = "build-omnix-source";
-              };
               binary-size-is-small = {
                 type = "app";
                 name = "check-closure-size";

--- a/nix/modules/flake-parts/om.nix
+++ b/nix/modules/flake-parts/om.nix
@@ -19,6 +19,10 @@
                 name = "check-closure-size";
                 systems = [ "x86_64-linux" ]; # We have static binary for Linux only.
               };
+              omnix-source-is-buildable = {
+                type = "app";
+                name = "omnix-source-is-buildable";
+              };
               cargo-tests = {
                 type = "devshell";
                 command = [ "just" "cargo-test" ];

--- a/nix/modules/flake-parts/rust.nix
+++ b/nix/modules/flake-parts/rust.nix
@@ -8,12 +8,41 @@
     inputs.process-compose-flake.flakeModule
     inputs.cargo-doc-live.flakeModule
   ];
-  perSystem = { config, self', pkgs, ... }: {
+  perSystem = { config, self', pkgs, lib, ... }: {
     cargo-doc-live.crateName = "omnix-gui";
 
     rust-project = {
       # See /crates/*/crate.nix for the crate-specific Nix configuration
       crateNixFile = "crate.nix";
+
+      # To avoid unnecessary rebuilds, start from cleaned source, and then add the Nix files necessary to `nix run` it. Finally, add any files required by the Rust build.
+      src =
+        let
+          # Like crane's filterCargoSources, but doesn't blindly include all TOML files!
+          filterCargoSources = path: type:
+            config.rust-project.crane-lib.filterCargoSources path type
+            && !(lib.hasSuffix ".toml" path && !lib.hasSuffix "Cargo.toml" path);
+        in
+        lib.cleanSourceWith {
+          src = inputs.self;
+          filter = path: type:
+            filterCargoSources path type
+            || lib.hasSuffix "registry.json" path
+            || lib.hasSuffix "crate.nix" path
+            || "${inputs.self}/flake.nix" == path
+            || "${inputs.self}/flake.lock" == path
+            # Select *only* the non-Rust files necessary to build omnix package.
+            || lib.hasSuffix "flake-parts/nixpkgs.nix" path
+            || lib.hasSuffix "flake-parts/rust.nix" path
+            || lib.hasSuffix "tests/flake.nix" path
+            || lib.hasSuffix "tests/flake.lock" path
+            || lib.hasSuffix "failing/flake.nix" path
+            || lib.hasSuffix "registry/flake.nix" path
+            || lib.hasSuffix "registry/flake.lock" path
+            || lib.hasSuffix "flake-schemas/flake.nix" path
+            || lib.hasSuffix "flake-schemas/flake.lock" path
+          ;
+        };
     };
 
     packages =
@@ -33,18 +62,16 @@
         });
       };
 
-    # Make sure that `OMNIX_SOURCE` is buildable.
-    # We must check this in CI, because it is built only during runtime otherwise (as part of `om ci run --on`).
-    apps.build-omnix-source = {
-      meta.description = "Build OMNIX_SOURCE";
-      program = pkgs.writeShellApplication {
-        name = "build-omnix-source";
-        runtimeInputs = [ pkgs.nix ];
-        text = ''
-          set -x
-          nix build -L --no-link --print-out-paths ${self'.packages.omnix-cli.OMNIX_SOURCE.outPath}
-        '';
-      };
-    };
+    checks.omnix-source-has-flake = pkgs.runCommand
+      "omnix-source-has-flake"
+      { buildInputs = [ pkgs.lsd ]; } ''
+      set -e
+      cd ${self'.packages.omnix-cli.OMNIX_SOURCE.outPath}
+      pwd
+      lsd --tree
+      test -f flake.nix
+      test -f flake.lock
+      touch $out
+    '';
   };
 }

--- a/nix/modules/flake-parts/rust.nix
+++ b/nix/modules/flake-parts/rust.nix
@@ -31,6 +31,7 @@
             || lib.hasSuffix "crate.nix" path
             || "${inputs.self}/flake.nix" == path
             || "${inputs.self}/flake.lock" == path
+            || "${inputs.self}/rust-toolchain.toml" == path
             # Select *only* the non-Rust files necessary to build omnix package.
             || lib.hasSuffix "flake-parts/nixpkgs.nix" path
             || lib.hasSuffix "flake-parts/rust.nix" path

--- a/nix/modules/flake-parts/rust.nix
+++ b/nix/modules/flake-parts/rust.nix
@@ -62,16 +62,18 @@
         });
       };
 
-    checks.omnix-source-has-flake = pkgs.runCommand
-      "omnix-source-has-flake"
-      { buildInputs = [ pkgs.lsd ]; } ''
-      set -e
-      cd ${self'.packages.omnix-cli.OMNIX_SOURCE.outPath}
-      pwd
-      lsd --tree
-      test -f flake.nix
-      test -f flake.lock
-      touch $out
-    '';
+    apps.omnix-source-is-buildable.program = pkgs.writeShellApplication {
+      name = "omnix-source-is-buildable";
+      runtimeInputs = [
+        pkgs.jq
+      ];
+      text = ''
+        set -e
+        cd ${self'.packages.omnix-cli.OMNIX_SOURCE.outPath}
+        # Make sure the drv evaluates (to test that no files are accidentally excluded)
+        nix --accept-flake-config --extra-experimental-features "flakes nix-command" \
+          derivation show "." | jq -r '.[].outputs.out.path'
+      '';
+    };
   };
 }


### PR DESCRIPTION
Also, 

- re-use` it in rust-project.src so we can test it as part of normal Nix build.
- actually evaluate $OMNIX_SOURCE to make sure it is buildable (this stopped happening somehow)