### PR TITLE
`om develop`: Allow non-default devShells

### DIFF
--- a/crates/omnix-cli/src/command/develop.rs
+++ b/crates/omnix-cli/src/command/develop.rs
@@ -1,13 +1,12 @@
-use std::path::PathBuf;
-
 use clap::Parser;
+use nix_rs::flake::url::FlakeUrl;
 
 /// Prepare to develop on a flake project
 #[derive(Parser, Debug)]
 pub struct DevelopCommand {
     /// Directory of the project
     #[arg(name = "DIR", default_value = ".")]
-    dir: PathBuf,
+    flake_shell: FlakeUrl,
 
     /// The stage to run in. If not provided, runs all stages.
     #[arg(long, value_enum)]
@@ -26,11 +25,9 @@ enum Stage {
 
 impl DevelopCommand {
     pub async fn run(&self) -> anyhow::Result<()> {
-        tracing::info!(
-            "⌨️  Preparing to develop project at {:}",
-            self.dir.display()
-        );
-        let prj = omnix_develop::core::Project::new(&self.dir).await?;
+        let flake = self.flake_shell.without_attr();
+        tracing::info!("⌨️  Preparing to develop project: {:}", &flake);
+        let prj = omnix_develop::core::Project::new(flake).await?;
         match self.stage {
             Some(Stage::PreShell) => omnix_develop::core::develop_on_pre_shell(&prj).await?,
             Some(Stage::PostShell) => omnix_develop::core::develop_on_post_shell(&prj).await?,

--- a/omnixrc
+++ b/omnixrc
@@ -8,7 +8,7 @@ use_omnix() {
     --accept-flake-config \
     --option builders '' \
     -j0 \
-    run github:juspay/omnix -- hack --stage=pre-shell $* || exit 1
+    run github:juspay/omnix -- develop --stage=pre-shell $* || exit 1
 
   use flake ${*:-.} --accept-flake-config
 
@@ -16,6 +16,6 @@ use_omnix() {
     # Nix shell failed; move on!
     exit
   else
-    nix --accept-flake-config run github:juspay/omnix -- hack --stage=post-shell $*
+    nix --accept-flake-config run github:juspay/omnix -- develop --stage=post-shell $*
   fi
 }


### PR DESCRIPTION
dir is only used for Markdown printing.

We need this to be able to pass custom devShell to `use flake`