### PR TITLE
`om ci`: Include systems (and flake) in result JSON

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           # Retrieve the store path for the given package out of the given subflake.
           get_output() {
             subflake=$1 name=$2 \
-            jq -r '.[$ENV.subflake].build.byName.[$ENV.name]' < $HOME/omci.json
+            jq -r '.result.[$ENV.subflake].build.byName.[$ENV.name]' < $HOME/omci.json
           }
 
           echo "OMCIJSON_PATH=$HOME/omci.json" >> "$GITHUB_OUTPUT"

--- a/crates/omnix-ci/src/command/run.rs
+++ b/crates/omnix-ci/src/command/run.rs
@@ -14,6 +14,7 @@ use nix_rs::{
 };
 use omnix_common::config::OmConfig;
 use omnix_health::{traits::Checkable, NixHealth};
+use serde::Serialize;
 
 use crate::{config::subflakes::SubflakesConfig, flake_ref::FlakeRef, step::core::StepsResult};
 
@@ -170,7 +171,7 @@ pub async fn ci_run(
     run_cmd: &RunCommand,
     cfg: &OmConfig<SubflakesConfig>,
     nix_config: &NixConfig,
-) -> anyhow::Result<HashMap<String, StepsResult>> {
+) -> anyhow::Result<RunResult> {
     let mut res = HashMap::new();
     let systems = run_cmd.get_systems(cmd, nix_config).await?;
 
@@ -208,5 +209,20 @@ pub async fn ci_run(
 
     tracing::info!("\n🥳 Success!");
 
-    Ok(res)
+    Ok(RunResult {
+        systems,
+        flake: cfg.flake_url.clone(),
+        result: res,
+    })
+}
+
+/// Results of the 'ci run' command
+#[derive(Debug, Serialize, Clone)]
+pub struct RunResult {
+    /// The systems we are building for
+    systems: Vec<System>,
+    /// The flake being built
+    flake: FlakeUrl,
+    /// CI result for each subflake
+    result: HashMap<String, StepsResult>,
 }


### PR DESCRIPTION
This breaks backwards compatibility.

---

Necessary towards: https://github.com/juspay/cachix-push/issues/8

```sh-session
$ jq -r --arg prefix "$(git branch --show-current)" 'if (.systems | length) != 1 then error("systems array must have exactly 1 element") else .systems[0] as $sys | .result.ROOT.build.byName | with_entries(.key = "\($prefix)-" + .key + "-\($sys)") | to_entries[] | [.key, .value] | .[] end' < json | xargs -n2 echo cachix pin mycache
cachix pin mycache main-ghc-shell-for-packages-0-x86_64-linux /nix/store/jx8rx1x2acn3r6jdwnp9cg4kjam9apyi-ghc-shell-for-packages-0
cachix pin mycache main-bar-x86_64-linux /nix/store/ckb05d6n10sammn4x2x9gqfwxnx5vhbg-bar-0.1.0.0
cachix pin mycache main-foo-x86_64-linux /nix/store/98sm6nw32jlhc9br83703zfxqk3d6ccx-foo-0.1.0.0
```


