### PR TITLE
`om health`: Improve tracing message for flake URL

### DIFF
--- a/crates/omnix-health/src/lib.rs
+++ b/crates/omnix-health/src/lib.rs
@@ -116,8 +116,11 @@ pub async fn run_all_checks_with(flake_url: Option<FlakeUrl>) -> anyhow::Result<
     }?;
 
     tracing::info!(
-        "🩺️ Checking the health of your Nix setup (flake={:?}",
-        flake_url.as_ref()
+        "🩺️ Checking the health of your Nix setup (flake: '{}')",
+        match flake_url.as_ref() {
+            Some(url) => url.to_string(),
+            None => "N/A".to_string(),
+        }
     );
 
     print_info_banner(flake_url.as_ref(), nix_info).await?;


### PR DESCRIPTION
This PR adds a missing parenthesis to a tracing message and, when at it, pretty prints the flake URL instead of leaking the Rust debug print of `Some(FlakeUrl(...))` or `None` to the user. This output is consistent with the `Flake` field in the printed table below.
Previously (note the missing ending parenthesis):
```
$ om health
...
🩺 Checking the health of your Nix setup (flake=None
...
```
and
```
$ om health "github:juspay/nixos-unified-template"
...
🩺 Checking the health of your Nix setup (flake=Some(FlakeUrl(github:juspay/nixos-unified-template))
...
```
Now:
```
$ om health
...
🩺 Checking the health of your Nix setup (flake: 'N/A')
──────────────────────────
 Property    Value
──────────────────────────
 Flake       N/A
...
```
and
```
$ om health "github:juspay/nixos-unified-template"
...
🩺 Checking the health of your Nix setup (flake: 'github:juspay/nixos-unified-template')
──────────────────────────────────────────────────
 Property    Value
──────────────────────────────────────────────────
 Flake       github:juspay/nixos-unified-template
...
```

`cargo test` fails on some unrelated issue which fails on `master` as well.