### PR TITLE
Fix: `just cargo-test` was erroneously running `cargo doc`

### DIFF
--- a/crates/omnix-ci/src/config/core.rs
+++ b/crates/omnix-ci/src/config/core.rs
@@ -10,15 +10,15 @@ mod tests {
     #[tokio::test]
     async fn test_config_loading() {
         // Testing this flake:
-        // https://github.com/srid/haskell-flake/blob/76214cf8b0d77ed763d1f093ddce16febaf07365/flake.nix#L15-L67
+        // https://github.com/srid/haskell-flake/blob/c60351652c71ebeb5dd237f7da874412a7a96970/flake.nix#L30-L95
         let url = &FlakeUrl(
-            "github:srid/haskell-flake/76214cf8b0d77ed763d1f093ddce16febaf07365#default.dev"
+            "github:srid/haskell-flake/c60351652c71ebeb5dd237f7da874412a7a96970#default.dev"
                 .to_string(),
         );
         let cfg = OmConfig::get(url).await.unwrap();
         let (config, attrs) = cfg.get_sub_config_under::<SubflakesConfig>("ci").unwrap();
         assert_eq!(attrs, &["dev"]);
         // assert_eq!(cfg.selected_subconfig, Some("dev".to_string()));
-        assert_eq!(config.0.len(), 7);
+        assert_eq!(config.0.len(), 9);
     }
 }

--- a/crates/omnix-cli/tests/command/ci.rs
+++ b/crates/omnix-cli/tests/command/ci.rs
@@ -109,7 +109,7 @@ async fn test_services_flake() -> anyhow::Result<()> {
     let expected = vec![
         "/nix/store/ib83flb2pqjb416qrjbs4pqhifa3hhs4-default-test",
         "/nix/store/l9c8y2xx2iffk8l1ipp4mkval8wl8paa-default",
-        "/nix/store/pj2l11lc4kai6av32hgfsrsvmga7vkhf-nix-shell"
+        "/nix/store/pj2l11lc4kai6av32hgfsrsvmga7vkhf-nix-shell",
     ]
     .into_iter()
     .map(|s| PathBuf::from(s.to_string()))

--- a/crates/omnix-cli/tests/command/ci.rs
+++ b/crates/omnix-cli/tests/command/ci.rs
@@ -93,8 +93,7 @@ async fn test_haskell_multi_nix_all_dependencies() -> anyhow::Result<()> {
 /// A test, with config
 async fn test_services_flake() -> anyhow::Result<()> {
     let outs = om_ci_run(&[
-        // TODO: Change after merging https://github.com/juspay/services-flake/pull/51
-        "github:juspay/services-flake/3d764f19d0a121915447641fe49a9b8d02777ff8",
+        "github:juspay/services-flake/23cf162387af041035072ee4a9de20f8408907cb#default.simple-example",
     ])
     .await?;
     let drv_outs: Vec<PathBuf> = outs
@@ -108,23 +107,9 @@ async fn test_services_flake() -> anyhow::Result<()> {
         })
         .collect();
     let expected = vec![
-        "/nix/store/1vlflyqyjnpa9089dgryrhpkypj9zg76-elasticsearch",
-        "/nix/store/20dz7z6pbzpx6sg61lf2sihj286zs3i2-postgres-test",
-        "/nix/store/4h6zn33lk2zpb7ch4ljd7ik6fk4cqdyi-nix-shell",
-        "/nix/store/6r5y4d7bmsqf0dk522rdkjd1q6ffiz2p-treefmt-check",
-        "/nix/store/87mhdmfs479rccyh89ss04ylj7rmbbyl-redis",
-        "/nix/store/8aq4awsrggaflv7lg5bp2qkmx52isqfk-redis-test",
-        "/nix/store/8xm6ccnbxkm2vapk084gmr89x8bvkh7i-redis-cluster-test",
-        "/nix/store/h604nx70yi7ca0zapwls6nlhy7n396lq-zookeeper-test",
-        "/nix/store/ibp162hp3wb3zz3hkwlfbq45ivmymj80-redis-cluster",
-        "/nix/store/ilx0c8gvyqviyn4wy0xsc8l9lmxq2g66-postgres",
-        "/nix/store/mhlzq02nmqn3wn4f2vhyq8sgf44siqkv-zookeeper",
-        "/nix/store/pahcafwnm9hj58wzlgfldm9k2g5794qr-nix-shell",
-        "/nix/store/pcds2jxvqr9ahyyff50r3qv5y5b944xz-default-test",
-        "/nix/store/pczvahjnzp01qzk1z4ixgialbmyxq3f0-apache-kafka-test",
-        "/nix/store/pl6m18fsz16kd59bg4myhvkfv04syb65-elasticsearch-test",
-        "/nix/store/wcvfpxciyv4v3w35fxc9axbvdv0lv13d-apache-kafka",
-        "/nix/store/y3xlr9fnsq43j175b3f69k5s7qw0gh8p-default",
+        "/nix/store/ib83flb2pqjb416qrjbs4pqhifa3hhs4-default-test",
+        "/nix/store/l9c8y2xx2iffk8l1ipp4mkval8wl8paa-default",
+        "/nix/store/pj2l11lc4kai6av32hgfsrsvmga7vkhf-nix-shell"
     ]
     .into_iter()
     .map(|s| PathBuf::from(s.to_string()))

--- a/crates/omnix-cli/tests/flake.lock
+++ b/crates/omnix-cli/tests/flake.lock
@@ -2188,17 +2188,17 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1693861687,
-        "narHash": "sha256-UyXmVc6l9JZqI8R6Gf5/+U7auwZcthB2GyCVYbI3Qdw=",
+        "lastModified": 1733013465,
+        "narHash": "sha256-neu7kBrPkI1fPU08kZHbt8EpArdqb38xUrChHqIO/3M=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "3d764f19d0a121915447641fe49a9b8d02777ff8",
+        "rev": "23cf162387af041035072ee4a9de20f8408907cb",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "3d764f19d0a121915447641fe49a9b8d02777ff8",
+        "rev": "23cf162387af041035072ee4a9de20f8408907cb",
         "type": "github"
       }
     },

--- a/crates/omnix-cli/tests/flake.nix
+++ b/crates/omnix-cli/tests/flake.nix
@@ -7,7 +7,7 @@
 
     # NOTE: These inputs should kept in sync with those used in the Rust source (cli.rs)
     haskell-multi-nix.url = "github:srid/haskell-multi-nix/c85563721c388629fa9e538a1d97274861bc8321";
-    services-flake.url = "github:juspay/services-flake/3d764f19d0a121915447641fe49a9b8d02777ff8";
+    services-flake.url = "github:juspay/services-flake/23cf162387af041035072ee4a9de20f8408907cb";
     nixos-config.url = "github:srid/nixos-config/fe9c16cc6a60bbc17646c15c8ce3c5380239ab92";
 
     # FIXME: Sadly, these will still result in rate-limiting errors, due to the 60/hour limit.

--- a/justfile
+++ b/justfile
@@ -42,4 +42,4 @@ cargo-doc:
 # Run cargo test for all crates
 [group('ci-steps')]
 cargo-test:
-    cargo doc --release --all-features --workspace
+    cargo test --release --all-features --workspace


### PR DESCRIPTION
Also fixes tests failing due to deprecation of `nixci` and `nix-health` flake configs. See
https://github.com/juspay/omnix/blob/df0093881be956a9df8034e5970dc363838bf478/doc/src/history.md?plain=1#L33


Notes on changes:
- `test_services_flake` doesn’t run `om ci` on all the sub-flakes (which was the case before) because unlike before we have a lot of services and since the goal of the test is to just check if the `stdout` is not polluted with non-outPaths, testing a smaller sub-flake should suffice.
- `test_config_loading` upgrades the commit of `haskell-flake` to the one that uses `om.ci` configuration.