### PR TITLE
`om ci`: Add devour-flake output path in result JSON

### DIFF
--- a/crates/omnix-ci/src/command/run.rs
+++ b/crates/omnix-ci/src/command/run.rs
@@ -33,6 +33,8 @@ pub struct RunCommand {
     /// Must be a flake reference which, when imported, must return a Nix list
     /// of systems. You may use one of the lists from
     /// <https://github.com/nix-systems>.
+    ///
+    /// You can also pass the individual system name, if they are supported by omnix.
     #[arg(long)]
     pub systems: Option<SystemsListFlakeRef>,
 


### PR DESCRIPTION
Useful to `nix copy` stuff back transitively (https://github.com/juspay/omnix/issues/358#issuecomment-2529325175).

![image](https://github.com/user-attachments/assets/d920e413-8911-4f55-abe2-bbf0c7d59056)
