### PR TITLE
Pass `--accept-flake-config` only during flake-related commands

### DIFF
--- a/crates/nix_rs/CHANGELOG.md
+++ b/crates/nix_rs/CHANGELOG.md
@@ -54,7 +54,7 @@
 - **`eval`**
   - `nix_eval_attr_json`
     - No longer takes `default_if_missing`; instead (always) returns `None` if attribute is missing.
-    - Rename to `nix_eval_attr` (as there is no non-JSON variant)
+    - Rename to `nix_eval_maybe` (as there is no non-JSON variant)
 - **`env::NixEnv`**
   - Clarify error message when `$USER` is not set
 - **``command`**

--- a/crates/nix_rs/src/command.rs
+++ b/crates/nix_rs/src/command.rs
@@ -58,7 +58,7 @@ impl Default for NixCmd {
             extra_experimental_features: vec![],
             extra_access_tokens: vec![],
             refresh: false,
-            accept_flake_config: true,
+            accept_flake_config: false,
         }
     }
 }
@@ -101,6 +101,7 @@ impl NixCmd {
 
     /// Enable flakes on this [NixCmd] configuration
     pub fn with_flakes(&mut self) {
+        self.accept_flake_config = true;
         self.extra_experimental_features
             .append(vec!["nix-command".to_string(), "flakes".to_string()].as_mut());
     }

--- a/crates/nix_rs/src/command.rs
+++ b/crates/nix_rs/src/command.rs
@@ -29,7 +29,7 @@ use crate::config::NixConfig;
 ///
 /// See [available global
 /// options](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix#options)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub struct NixCmd {
     /// Append to the experimental-features setting of Nix.
@@ -43,24 +43,6 @@ pub struct NixCmd {
     /// Consider all previously downloaded files out-of-date.
     #[cfg_attr(feature = "clap", arg(long))]
     pub refresh: bool,
-
-    /// Accept `nixConfig` configuration in flake.nix
-    #[cfg_attr(feature = "clap", arg(long))]
-    pub accept_flake_config: bool,
-}
-
-impl Default for NixCmd {
-    /// The default `nix` command
-    ///
-    /// See [NixCmd::get] for the flakes enabled version.
-    fn default() -> Self {
-        Self {
-            extra_experimental_features: vec![],
-            extra_access_tokens: vec![],
-            refresh: false,
-            accept_flake_config: false,
-        }
-    }
 }
 
 static NIXCMD: OnceCell<NixCmd> = OnceCell::const_new();
@@ -101,7 +83,6 @@ impl NixCmd {
 
     /// Enable flakes on this [NixCmd] configuration
     pub fn with_flakes(&mut self) {
-        self.accept_flake_config = true;
         self.extra_experimental_features
             .append(vec!["nix-command".to_string(), "flakes".to_string()].as_mut());
     }
@@ -210,9 +191,6 @@ impl NixCmd {
         }
         if self.refresh {
             args.push("--refresh".to_string());
-        }
-        if self.accept_flake_config {
-            args.push("--accept-flake-config".to_string());
         }
         args
     }

--- a/crates/nix_rs/src/command.rs
+++ b/crates/nix_rs/src/command.rs
@@ -148,9 +148,9 @@ impl NixCmd {
         if out.status.success() {
             Ok(out.stdout)
         } else {
-            let stderr = String::from_utf8(out.stderr)?;
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
             Err(CommandError::ProcessFailed {
-                stderr: Some(stderr),
+                stderr,
                 exit_code: out.status.code(),
             })
         }
@@ -170,8 +170,9 @@ impl NixCmd {
         if out.status.success() {
             Ok(out.stdout)
         } else {
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
             Err(CommandError::ProcessFailed {
-                stderr: None,
+                stderr,
                 exit_code: out.status.code(),
             })
         }
@@ -255,16 +256,13 @@ pub enum CommandError {
 
     /// Child process exited unsuccessfully
     #[error(
-        "Process exited unsuccessfully. exit_code={:?}{}",
+        "Process exited unsuccessfully. exit_code={:?} stderr={}",
         exit_code,
-        match stderr {
-            Some(s) => format!(" stderr={}", s),
-            None => "".to_string()
-        },
+        stderr
     )]
     ProcessFailed {
         /// The stderr of the process, if available.
-        stderr: Option<String>,
+        stderr: String,
         /// The exit code of the process
         exit_code: Option<i32>,
     },

--- a/crates/nix_rs/src/flake/command.rs
+++ b/crates/nix_rs/src/flake/command.rs
@@ -71,8 +71,8 @@ pub async fn lock(
     url: &FlakeUrl,
 ) -> Result<(), NixCmdError> {
     cmd.run_with(|c| {
-        opts.use_in_command(c);
         c.args(["flake", "lock", url]);
+        opts.use_in_command(c);
         c.args(args);
     })
     .await?;
@@ -82,8 +82,8 @@ pub async fn lock(
 /// Run `nix flake check`
 pub async fn check(cmd: &NixCmd, opts: &FlakeOptions, url: &FlakeUrl) -> Result<(), NixCmdError> {
     cmd.run_with(|c| {
-        opts.use_in_command(c);
         c.args(["flake", "check", url]);
+        opts.use_in_command(c);
     })
     .await?;
     Ok(())

--- a/crates/nix_rs/src/flake/command.rs
+++ b/crates/nix_rs/src/flake/command.rs
@@ -63,6 +63,22 @@ pub async fn build(
     Ok(v)
 }
 
+/// Run `nix flake lock`
+pub async fn lock(
+    cmd: &NixCmd,
+    opts: &FlakeOptions,
+    args: &[&str],
+    url: &FlakeUrl,
+) -> Result<(), NixCmdError> {
+    cmd.run_with(|c| {
+        opts.use_in_command(c);
+        c.args(["flake", "lock", url]);
+        c.args(args);
+    })
+    .await?;
+    Ok(())
+}
+
 /// A path built by nix, as returned by --print-out-paths
 #[derive(Serialize, Deserialize)]
 pub struct OutPath {

--- a/crates/nix_rs/src/flake/command.rs
+++ b/crates/nix_rs/src/flake/command.rs
@@ -79,6 +79,16 @@ pub async fn lock(
     Ok(())
 }
 
+/// Run `nix flake check`
+pub async fn check(cmd: &NixCmd, opts: &FlakeOptions, url: &FlakeUrl) -> Result<(), NixCmdError> {
+    cmd.run_with(|c| {
+        opts.use_in_command(c);
+        c.args(["flake", "check", url]);
+    })
+    .await?;
+    Ok(())
+}
+
 /// A path built by nix, as returned by --print-out-paths
 #[derive(Serialize, Deserialize)]
 pub struct OutPath {

--- a/crates/nix_rs/src/flake/eval.rs
+++ b/crates/nix_rs/src/flake/eval.rs
@@ -20,7 +20,7 @@ where
             cmd.args(["eval", "--json"]);
             opts.use_in_command(cmd);
             cmd.arg(url.to_string());
-            // Avoid Nix from dumping logs related to `--override-input` use. Yes, this requires *double* use of `--quiet`. Also, `-qq` won't work until https://github.com/NixOS/nix/pull/11652
+            // Avoid Nix from dumping logs related to `--override-input` use. Yes, this requires *double* use of `--quiet`.
             cmd.args(["--quiet", "--quiet"]);
         })
         .await?;
@@ -28,18 +28,16 @@ where
     Ok(v)
 }
 
-/// Like [nix_eval] but takes an attribute to evaluate.
-///
-/// If the attribute is missing, return None.
-///
-/// TODO: Remove this function in favour of [nix_eval]
-pub async fn nix_eval_attr<T>(cmd: &NixCmd, url: &FlakeUrl) -> Result<Option<T>, NixCmdError>
+/// Like [nix_eval] but return `None` if the attribute is missing
+pub async fn nix_eval_maybe<T>(
+    cmd: &NixCmd,
+    opts: &FlakeOptions,
+    url: &FlakeUrl,
+) -> Result<Option<T>, NixCmdError>
 where
     T: Default + serde::de::DeserializeOwned,
 {
-    let result = cmd
-        .run_with_args_expecting_json(&["eval", &url.0, "--json"])
-        .await;
+    let result = nix_eval(cmd, opts, url).await;
     match result {
         Ok(v) => Ok(Some(v)),
         Err(err) if error_is_missing_attribute(&err) => {

--- a/crates/nix_rs/src/flake/eval.rs
+++ b/crates/nix_rs/src/flake/eval.rs
@@ -14,18 +14,7 @@ pub async fn nix_eval<T>(
 where
     T: serde::de::DeserializeOwned,
 {
-    let stdout = nixcmd
-        .run_with(|cmd| {
-            cmd.stdout(Stdio::piped());
-            cmd.args(["eval", "--json"]);
-            opts.use_in_command(cmd);
-            cmd.arg(url.to_string());
-            // Avoid Nix from dumping logs related to `--override-input` use. Yes, this requires *double* use of `--quiet`.
-            cmd.args(["--quiet", "--quiet"]);
-        })
-        .await?;
-    let v = serde_json::from_slice::<T>(&stdout)?;
-    Ok(v)
+    nix_eval_(nixcmd, opts, url, false).await
 }
 
 /// Like [nix_eval] but return `None` if the attribute is missing
@@ -37,7 +26,7 @@ pub async fn nix_eval_maybe<T>(
 where
     T: Default + serde::de::DeserializeOwned,
 {
-    let result = nix_eval(cmd, opts, url).await;
+    let result = nix_eval_(cmd, opts, url, true).await;
     match result {
         Ok(v) => Ok(Some(v)),
         Err(err) if error_is_missing_attribute(&err) => {
@@ -47,17 +36,38 @@ where
     }
 }
 
+async fn nix_eval_<T>(
+    nixcmd: &NixCmd,
+    opts: &FlakeOptions,
+    url: &FlakeUrl,
+    capture_stderr: bool,
+) -> Result<T, NixCmdError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let stdout = nixcmd
+        .run_with(|cmd| {
+            cmd.stdout(Stdio::piped());
+            if capture_stderr {
+                cmd.stderr(Stdio::piped());
+            }
+            cmd.args(["eval", "--json"]);
+            opts.use_in_command(cmd);
+            cmd.arg(url.to_string());
+            // Avoid Nix from dumping logs related to `--override-input` use. Yes, this requires *double* use of `--quiet`.
+            cmd.args(["--quiet", "--quiet"]);
+        })
+        .await?;
+    let v = serde_json::from_slice::<T>(&stdout)?;
+    Ok(v)
+}
+
 /// Check that [NixCmdError] is a missing attribute error
 fn error_is_missing_attribute(err: &NixCmdError) -> bool {
-    match err {
-        NixCmdError::CmdError(CommandError::ProcessFailed { stderr, .. }) => {
-            if let Some(stderr) = stderr {
-                if stderr.contains("does not provide attribute") {
-                    return true;
-                }
-            }
-            false
+    if let NixCmdError::CmdError(CommandError::ProcessFailed { stderr, .. }) = err {
+        if stderr.contains("does not provide attribute") {
+            return true;
         }
-        _ => false,
     }
+    false
 }

--- a/crates/nix_rs/src/store/command.rs
+++ b/crates/nix_rs/src/store/command.rs
@@ -131,7 +131,7 @@ async fn run_awaiting_stdout(cmd: &mut Command) -> Result<Vec<u8>, NixStoreCmdEr
     if out.status.success() {
         Ok(out.stdout)
     } else {
-        let stderr = Some(String::from_utf8_lossy(&out.stderr).to_string());
+        let stderr = String::from_utf8_lossy(&out.stderr).to_string();
         let exit_code = out.status.code();
         Err(CommandError::ProcessFailed { stderr, exit_code }.into())
     }

--- a/crates/omnix-ci/src/nix/lock.rs
+++ b/crates/omnix-ci/src/nix/lock.rs
@@ -1,19 +1,19 @@
 //! Functions for working with `nix flake lock`.
-use std::process::Stdio;
 
-use anyhow::{bail, Result};
-use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
+use anyhow::{Ok, Result};
+use nix_rs::{
+    command::NixCmd,
+    flake::{self, command::FlakeOptions, url::FlakeUrl},
+};
 
 /// Make sure that the `flake.lock` file is in sync.
 pub async fn nix_flake_lock_check(nixcmd: &NixCmd, url: &FlakeUrl) -> Result<()> {
-    let mut cmd = nixcmd.command();
-    cmd.args(["flake", "lock", "--no-update-lock-file", &url.0]);
-    nix_rs::command::trace_cmd(&cmd);
-    let status = cmd.stdin(Stdio::null()).spawn()?.wait().await?;
-    if status.success() {
-        Ok(())
-    } else {
-        let exit_code = status.code().unwrap_or(1);
-        bail!("nix flake lock failed to run (exited: {})", exit_code);
-    }
+    flake::command::lock(
+        nixcmd,
+        &FlakeOptions::default(),
+        &["--no-update-lock-file"],
+        url,
+    )
+    .await?;
+    Ok(())
 }

--- a/crates/omnix-ci/src/step/flake_check.rs
+++ b/crates/omnix-ci/src/step/flake_check.rs
@@ -1,6 +1,9 @@
 //! The cachix step
 use colored::Colorize;
-use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
+use nix_rs::{
+    command::NixCmd,
+    flake::{self, command::FlakeOptions, url::FlakeUrl},
+};
 use serde::Deserialize;
 
 use crate::config::subflake::SubflakeConfig;
@@ -33,15 +36,11 @@ impl FlakeCheckStep {
             format!("🩺 Running flake check on: {}", subflake.dir).bold()
         );
         let sub_flake_url = url.sub_flake_url(subflake.dir.clone());
-        let mut args = vec!["flake", "check", &sub_flake_url];
-        for (k, v) in &subflake.override_inputs {
-            args.extend(["--override-input", k, v]);
-        }
-        nixcmd
-            .run_with(|cmd| {
-                cmd.args(args);
-            })
-            .await?;
+        let opts = FlakeOptions {
+            override_inputs: subflake.override_inputs.clone(),
+            ..Default::default()
+        };
+        flake::command::check(nixcmd, &opts, &sub_flake_url).await?;
         Ok(())
     }
 }

--- a/crates/omnix-common/src/config.rs
+++ b/crates/omnix-common/src/config.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use nix_rs::{
     command::NixCmd,
-    flake::{eval::nix_eval_attr, metadata::FlakeMetadata, url::FlakeUrl},
+    flake::{command::FlakeOptions, eval::nix_eval_maybe, metadata::FlakeMetadata, url::FlakeUrl},
 };
 use serde::{de::DeserializeOwned, Deserialize};
 #[cfg(test)]
@@ -63,9 +63,13 @@ impl OmConfig {
         Ok(OmConfig {
             flake_url: flake_url.without_attr(),
             reference: flake_url.get_attr().as_list(),
-            config: nix_eval_attr(NixCmd::get().await, &flake_url.with_attr("om"))
-                .await?
-                .unwrap_or_default(),
+            config: nix_eval_maybe(
+                NixCmd::get().await,
+                &FlakeOptions::default(),
+                &flake_url.with_attr("om"),
+            )
+            .await?
+            .unwrap_or_default(),
         })
     }
 

--- a/crates/omnix-init/src/test.rs
+++ b/crates/omnix-init/src/test.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path};
 use anyhow::Context;
 use nix_rs::{
     command::NixCmd,
-    flake::{system::System, url::FlakeUrl},
+    flake::{command::FlakeOptions, system::System, url::FlakeUrl},
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -102,6 +102,7 @@ impl Asserts {
         for (attr, package) in self.packages.iter() {
             let paths = nix_rs::flake::command::build(
                 &NixCmd::default(),
+                &FlakeOptions::default(),
                 FlakeUrl::from(dir).with_attr(attr),
             )
             .await?;

--- a/justfile
+++ b/justfile
@@ -22,12 +22,17 @@ alias w := watch
 # Run CI locally
 [group('ci')]
 ci:
-    nix run . ci
+    nix --accept-flake-config run . ci
 
 # Run CI locally in devShell (using cargo)
 [group('ci')]
 ci-cargo:
     cargo run -p omnix-cli -- ci run
+
+# Run CI locally in devShell (using cargo) on a simple flake with subflakes
+[group('ci')]
+ci-cargo-ext:
+    cargo run -p omnix-cli -- ci run github:srid/nixos-unified
 
 # Do clippy checks for all crates
 [group('ci-steps')]


### PR DESCRIPTION
`--accept-flake-config` expects the flake to be already enabled, which will fail `om health` on systems with flake not enabled.

## Error

```
❄️  nix --accept-flake-config --version️
Error: Unable to gather nix info

Caused by:
    0: Nix command error: Command error: Process exited unsuccessfully. exit_code=Some(1) stderr=error: experimental Nix feature 'flakes' is disabled; add '--extra-experimental-features flakes' to enable it

    1: Command error: Process exited unsuccessfully. exit_code=Some(1) stderr=error: experimental Nix feature 'flakes' is disabled; add '--extra-experimental-features flakes' to enable it

    2: Process exited unsuccessfully. exit_code=Some(1) stderr=error: experimental Nix feature 'flakes' is disabled; add '--extra-experimental-features flakes' to enable it
```