### PR TITLE
health(shell): Fail if there are unmanaged dotfiles

### DIFF
--- a/crates/omnix-health/src/check/shell.rs
+++ b/crates/omnix-health/src/check/shell.rs
@@ -60,7 +60,8 @@ impl Checkable for ShellCheck {
             "Shell={:?}; HOME={:?}; Managed: {:?}; Unmanaged: {:?}",
             user_shell_env.shell, user_shell_env.home, managed, unmanaged
         );
-        let result = if !managed.is_empty() {
+        let result = if !managed.is_empty() && unmanaged.is_empty() {
+            // If *all* dotfiles are managed, then we are good
             CheckResult::Green
         } else {
             CheckResult::Red {

--- a/crates/omnix-health/src/check/shell.rs
+++ b/crates/omnix-health/src/check/shell.rs
@@ -46,12 +46,12 @@ impl Checkable for ShellCheck {
 
         // Iterate over each dotfile and check if it is managed by Nix
         let mut managed: HashMap<&'static str, PathBuf> = HashMap::new();
-        let mut unmanaged: Vec<PathBuf> = Vec::new();
+        let mut unmanaged: HashMap<&'static str, PathBuf> = HashMap::new();
         for (name, path) in user_shell_env.dotfiles {
             if super::direnv::is_path_in_nix_store(&path) {
                 managed.insert(name, path.clone());
             } else {
-                unmanaged.push(path.clone());
+                unmanaged.insert(name, path.clone());
             }
         }
 


### PR DESCRIPTION
Follow-up #366 and resolves #365

![image](https://github.com/user-attachments/assets/bb549970-1527-4fab-99e3-a0f19ea746a1)
