### PR TITLE
ci: Fix `—override-input` not being processed for `om ci run —on`

### DIFF
--- a/crates/omnix-ci/src/command/core.rs
+++ b/crates/omnix-ci/src/command/core.rs
@@ -27,13 +27,6 @@ impl Default for Command {
 }
 
 impl Command {
-    /// Pre-process `Command`
-    pub fn preprocess(&mut self) {
-        if let Command::Run(cmd) = self {
-            cmd.preprocess()
-        }
-    }
-
     /// Run the command
     #[instrument(name = "run", skip(self))]
     pub async fn run(self, nixcmd: &NixCmd, verbose: bool) -> anyhow::Result<()> {

--- a/crates/omnix-ci/src/command/run.rs
+++ b/crates/omnix-ci/src/command/run.rs
@@ -99,7 +99,12 @@ impl RunCommand {
     pub async fn run(&self, nixcmd: &NixCmd, verbose: bool, cfg: OmConfig) -> anyhow::Result<()> {
         match &self.on {
             Some(store_uri) => run_remote::run_on_remote_store(nixcmd, self, &cfg, store_uri).await,
-            None => self.run_local(nixcmd, verbose, cfg).await,
+            None => {
+                // preprocess the command when running ci locally
+                let mut cmd = self.clone();
+                cmd.preprocess();
+                cmd.run_local(nixcmd, verbose, cfg).await
+            }
         }
     }
 

--- a/crates/omnix-cli/src/command/ci.rs
+++ b/crates/omnix-cli/src/command/ci.rs
@@ -27,8 +27,6 @@ impl CICommand {
     ///
     /// If the user has not provided one, return the build command by default.
     fn command(&self) -> Command {
-        let mut cmd = self.command.clone().unwrap_or_default();
-        cmd.preprocess();
-        cmd
+        self.command.clone().unwrap_or_default()
     }
 }


### PR DESCRIPTION
Resolves #368 