### PR TITLE
`om health`: Add `--json`

### DIFF
--- a/crates/omnix-ci/src/command/run.rs
+++ b/crates/omnix-ci/src/command/run.rs
@@ -198,7 +198,7 @@ pub async fn check_nix_version(cfg: &OmConfig, nix_info: &NixInfo) -> anyhow::Re
     let checks = omnix_health
         .nix_version
         .check(nix_info, Some(&cfg.flake_url));
-    let exit_code = NixHealth::print_report_returning_exit_code(&checks).await?;
+    let exit_code = NixHealth::print_report_returning_exit_code(&checks, false).await?;
 
     if exit_code != 0 {
         std::process::exit(exit_code);

--- a/crates/omnix-cli/src/command/health.rs
+++ b/crates/omnix-cli/src/command/health.rs
@@ -25,12 +25,8 @@ impl HealthCommand {
             println!("{}", NixHealth::schema()?);
             return Ok(());
         }
-        let checks_map = run_all_checks_with(self.flake_url.clone()).await?;
-        let exit_code = if self.json {
-            NixHealth::print_json_report_returning_exit_code(&checks_map).await?
-        } else {
-            NixHealth::print_report_returning_exit_code(&checks_map).await?
-        };
+        let checks = run_all_checks_with(self.flake_url.clone()).await?;
+        let exit_code = NixHealth::print_report_returning_exit_code(&checks, self.json).await?;
         if exit_code != 0 {
             std::process::exit(exit_code);
         }

--- a/crates/omnix-cli/src/command/health.rs
+++ b/crates/omnix-cli/src/command/health.rs
@@ -13,6 +13,10 @@ pub struct HealthCommand {
     /// a flake.nix)
     #[arg(long = "dump-schema")]
     pub dump_schema: bool,
+
+    /// Print output in JSON
+    #[arg(long)]
+    json: bool,
 }
 
 impl HealthCommand {
@@ -21,8 +25,12 @@ impl HealthCommand {
             println!("{}", NixHealth::schema()?);
             return Ok(());
         }
-        let checks = run_all_checks_with(self.flake_url.clone()).await?;
-        let exit_code = NixHealth::print_report_returning_exit_code(&checks).await?;
+        let checks_map = run_all_checks_with(self.flake_url.clone()).await?;
+        let exit_code = if self.json {
+            NixHealth::print_json_report_returning_exit_code(&checks_map).await?
+        } else {
+            NixHealth::print_report_returning_exit_code(&checks_map).await?
+        };
         if exit_code != 0 {
             std::process::exit(exit_code);
         }

--- a/crates/omnix-develop/src/core.rs
+++ b/crates/omnix-develop/src/core.rs
@@ -73,7 +73,7 @@ pub async fn develop_on_pre_shell(prj: &Project) -> anyhow::Result<()> {
     };
 
     for check_kind in relevant_checks.into_iter() {
-        for check in check_kind.check(nix_info, Some(&prj.flake)).values() {
+        for (_, check) in check_kind.check(nix_info, Some(&prj.flake)) {
             if !check.result.green() {
                 check.tracing_log().await?;
                 if !check.result.green() && check.required {

--- a/crates/omnix-develop/src/core.rs
+++ b/crates/omnix-develop/src/core.rs
@@ -73,7 +73,7 @@ pub async fn develop_on_pre_shell(prj: &Project) -> anyhow::Result<()> {
     };
 
     for check_kind in relevant_checks.into_iter() {
-        for check in check_kind.check(nix_info, Some(&prj.flake)) {
+        for check in check_kind.check(nix_info, Some(&prj.flake)).values() {
             if !check.result.green() {
                 check.tracing_log().await?;
                 if !check.result.green() && check.required {

--- a/crates/omnix-health/src/check/caches.rs
+++ b/crates/omnix-health/src/check/caches.rs
@@ -62,7 +62,7 @@ impl Checkable for Caches {
             required: true,
         };
 
-        [("caches", check)].into_iter().collect()
+        vec![("caches", check)]
     }
 }
 

--- a/crates/omnix-health/src/check/caches.rs
+++ b/crates/omnix-health/src/check/caches.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nix_rs::info;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -27,7 +25,7 @@ impl Checkable for Caches {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<&'static str, Check> {
+    ) -> Vec<(&'static str, Check)> {
         let missing_caches = self.get_missing_caches(nix_info);
         let result = if missing_caches.is_empty() {
             CheckResult::Green

--- a/crates/omnix-health/src/check/caches.rs
+++ b/crates/omnix-health/src/check/caches.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nix_rs::info;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -25,7 +27,7 @@ impl Checkable for Caches {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check> {
+    ) -> HashMap<String, Check> {
         let missing_caches = self.get_missing_caches(nix_info);
         let result = if missing_caches.is_empty() {
             CheckResult::Green
@@ -61,7 +63,10 @@ impl Checkable for Caches {
             result,
             required: true,
         };
-        vec![check]
+
+        let mut checks_map = HashMap::new();
+        checks_map.insert("caches".to_string(), check);
+        checks_map
     }
 }
 

--- a/crates/omnix-health/src/check/caches.rs
+++ b/crates/omnix-health/src/check/caches.rs
@@ -27,7 +27,7 @@ impl Checkable for Caches {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check> {
+    ) -> HashMap<&'static str, Check> {
         let missing_caches = self.get_missing_caches(nix_info);
         let result = if missing_caches.is_empty() {
             CheckResult::Green
@@ -64,9 +64,7 @@ impl Checkable for Caches {
             required: true,
         };
 
-        let mut checks_map = HashMap::new();
-        checks_map.insert("caches".to_string(), check);
-        checks_map
+        [("caches", check)].into_iter().collect()
     }
 }
 

--- a/crates/omnix-health/src/check/direnv.rs
+++ b/crates/omnix-health/src/check/direnv.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nix_rs::{flake::url::FlakeUrl, info};
 use serde::{Deserialize, Serialize};
 
@@ -28,17 +26,17 @@ impl Checkable for Direnv {
         &self,
         _nix_info: &info::NixInfo,
         flake_url: Option<&FlakeUrl>,
-    ) -> HashMap<&'static str, Check> {
-        let mut checks = HashMap::new();
+    ) -> Vec<(&'static str, Check)> {
+        let mut checks = vec![];
         if !self.enable {
             return checks;
         }
 
         let direnv_install_result = direnv::DirenvInstall::detect();
-        checks.insert(
+        checks.push((
             "direnv-install-check",
             install_check(&direnv_install_result, self.required),
-        );
+        ));
 
         match direnv_install_result.as_ref() {
             Err(_) => return checks,
@@ -49,10 +47,10 @@ impl Checkable for Direnv {
                     None => {}
                     Some(local_path) => {
                         if local_path.join(".envrc").exists() {
-                            checks.insert(
+                            checks.push((
                                 "direnv-allowed-check",
                                 allowed_check(direnv_install, local_path, self.required),
-                            );
+                            ));
                         }
                     }
                 }

--- a/crates/omnix-health/src/check/direnv.rs
+++ b/crates/omnix-health/src/check/direnv.rs
@@ -24,17 +24,24 @@ impl Default for Direnv {
 }
 
 impl Checkable for Direnv {
-    fn check(&self, _nix_info: &info::NixInfo, flake_url: Option<&FlakeUrl>) -> HashMap<String, Check> {
-        let mut checks_map = HashMap::new();
+    fn check(
+        &self,
+        _nix_info: &info::NixInfo,
+        flake_url: Option<&FlakeUrl>,
+    ) -> HashMap<&'static str, Check> {
+        let mut checks = HashMap::new();
         if !self.enable {
-            return checks_map;
+            return checks;
         }
 
         let direnv_install_result = direnv::DirenvInstall::detect();
-        checks_map.insert("direnv-install-check".to_string(), install_check(&direnv_install_result, self.required));
+        checks.insert(
+            "direnv-install-check",
+            install_check(&direnv_install_result, self.required),
+        );
 
         match direnv_install_result.as_ref() {
-            Err(_) => return checks_map,
+            Err(_) => return checks,
             Ok(direnv_install) => {
                 // If direnv is installed, check for version and then allowed_check
                 // This check is currently only relevant if the flake is local and an `.envrc` exists.
@@ -42,14 +49,17 @@ impl Checkable for Direnv {
                     None => {}
                     Some(local_path) => {
                         if local_path.join(".envrc").exists() {
-                            checks_map.insert("direnv-allowed-check".to_string(), allowed_check(direnv_install, local_path, self.required));
+                            checks.insert(
+                                "direnv-allowed-check",
+                                allowed_check(direnv_install, local_path, self.required),
+                            );
                         }
                     }
                 }
             }
         }
 
-        checks_map
+        checks
     }
 }
 

--- a/crates/omnix-health/src/check/flake_enabled.rs
+++ b/crates/omnix-health/src/check/flake_enabled.rs
@@ -15,7 +15,7 @@ impl Checkable for FlakeEnabled {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check> {
+    ) -> HashMap<&'static str, Check> {
         let val = &nix_info.nix_config.experimental_features.value;
         let check = Check {
             title: "Flakes Enabled".to_string(),
@@ -33,8 +33,6 @@ impl Checkable for FlakeEnabled {
             required: true,
         };
 
-        let mut checks_map = HashMap::new();
-        checks_map.insert("flake-enabled".to_string(), check);
-        checks_map
+        [("flake-enabled", check)].into_iter().collect()
     }
 }

--- a/crates/omnix-health/src/check/flake_enabled.rs
+++ b/crates/omnix-health/src/check/flake_enabled.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +15,7 @@ impl Checkable for FlakeEnabled {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check> {
+    ) -> HashMap<String, Check> {
         let val = &nix_info.nix_config.experimental_features.value;
         let check = Check {
             title: "Flakes Enabled".to_string(),
@@ -30,6 +32,9 @@ impl Checkable for FlakeEnabled {
             },
             required: true,
         };
-        vec![check]
+
+        let mut checks_map = HashMap::new();
+        checks_map.insert("flake-enabled".to_string(), check);
+        checks_map
     }
 }

--- a/crates/omnix-health/src/check/flake_enabled.rs
+++ b/crates/omnix-health/src/check/flake_enabled.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +13,7 @@ impl Checkable for FlakeEnabled {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<&'static str, Check> {
+    ) -> Vec<(&'static str, Check)> {
         let val = &nix_info.nix_config.experimental_features.value;
         let check = Check {
             title: "Flakes Enabled".to_string(),
@@ -33,6 +31,6 @@ impl Checkable for FlakeEnabled {
             required: true,
         };
 
-        [("flake-enabled", check)].into_iter().collect()
+        vec![("flake-enabled", check)]
     }
 }

--- a/crates/omnix-health/src/check/max_jobs.rs
+++ b/crates/omnix-health/src/check/max_jobs.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +13,7 @@ impl Checkable for MaxJobs {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<&'static str, Check> {
+    ) -> Vec<(&'static str, Check)> {
         let max_jobs = nix_info.nix_config.max_jobs.value;
         let check = Check {
             title: "Max Jobs".to_string(),
@@ -34,6 +32,6 @@ impl Checkable for MaxJobs {
             required: true,
         };
 
-        [("max-jobs", check)].into_iter().collect()
+        vec![("max-jobs", check)]
     }
 }

--- a/crates/omnix-health/src/check/max_jobs.rs
+++ b/crates/omnix-health/src/check/max_jobs.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +15,7 @@ impl Checkable for MaxJobs {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check> {
+    ) -> HashMap<String, Check> {
         let max_jobs = nix_info.nix_config.max_jobs.value;
         let check = Check {
             title: "Max Jobs".to_string(),
@@ -31,6 +33,9 @@ impl Checkable for MaxJobs {
             },
             required: true,
         };
-        vec![check]
+
+        let mut checks_map = HashMap::new();
+        checks_map.insert("max-jobs".to_string(), check);
+        checks_map
     }
 }

--- a/crates/omnix-health/src/check/max_jobs.rs
+++ b/crates/omnix-health/src/check/max_jobs.rs
@@ -15,7 +15,7 @@ impl Checkable for MaxJobs {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check> {
+    ) -> HashMap<&'static str, Check> {
         let max_jobs = nix_info.nix_config.max_jobs.value;
         let check = Check {
             title: "Max Jobs".to_string(),
@@ -34,8 +34,6 @@ impl Checkable for MaxJobs {
             required: true,
         };
 
-        let mut checks_map = HashMap::new();
-        checks_map.insert("max-jobs".to_string(), check);
-        checks_map
+        [("max-jobs", check)].into_iter().collect()
     }
 }

--- a/crates/omnix-health/src/check/min_nix_version.rs
+++ b/crates/omnix-health/src/check/min_nix_version.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nix_rs::version::NixVersion;
 
 use nix_rs::info;
@@ -31,7 +29,7 @@ impl Checkable for MinNixVersion {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<&'static str, Check> {
+    ) -> Vec<(&'static str, Check)> {
         let val = &nix_info.nix_version;
         let check = Check {
             title: "Minimum Nix Version".to_string(),
@@ -47,6 +45,6 @@ impl Checkable for MinNixVersion {
             required: true,
         };
 
-        [("nix-version", check)].into_iter().collect()
+        vec![("nix-version", check)]
     }
 }

--- a/crates/omnix-health/src/check/min_nix_version.rs
+++ b/crates/omnix-health/src/check/min_nix_version.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nix_rs::version::NixVersion;
 
 use nix_rs::info;
@@ -29,7 +31,7 @@ impl Checkable for MinNixVersion {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check> {
+    ) -> HashMap<String, Check> {
         let val = &nix_info.nix_version;
         let check = Check {
             title: "Minimum Nix Version".to_string(),
@@ -44,6 +46,9 @@ impl Checkable for MinNixVersion {
             },
             required: true,
         };
-        vec![check]
+
+        let mut checks_map = HashMap::new();
+        checks_map.insert("nix-version".to_string(), check);
+        checks_map
     }
 }

--- a/crates/omnix-health/src/check/min_nix_version.rs
+++ b/crates/omnix-health/src/check/min_nix_version.rs
@@ -31,7 +31,7 @@ impl Checkable for MinNixVersion {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check> {
+    ) -> HashMap<&'static str, Check> {
         let val = &nix_info.nix_version;
         let check = Check {
             title: "Minimum Nix Version".to_string(),
@@ -47,8 +47,6 @@ impl Checkable for MinNixVersion {
             required: true,
         };
 
-        let mut checks_map = HashMap::new();
-        checks_map.insert("nix-version".to_string(), check);
-        checks_map
+        [("nix-version", check)].into_iter().collect()
     }
 }

--- a/crates/omnix-health/src/check/rosetta.rs
+++ b/crates/omnix-health/src/check/rosetta.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nix_rs::{
     env::{AppleEmulation, MacOSArch, OS},
     info,
@@ -30,8 +32,8 @@ impl Checkable for Rosetta {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check> {
-        let mut checks = vec![];
+    ) -> HashMap<String, Check> {
+        let mut checks_map = HashMap::new();
         if let (true, Some(emulation)) = (self.enable, get_apple_emulation(&nix_info.nix_env.os)) {
             let check = Check {
                 title: "Rosetta Not Active".to_string(),
@@ -46,9 +48,9 @@ impl Checkable for Rosetta {
                 },
                 required: self.required,
             };
-            checks.push(check);
+            checks_map.insert("rosetta".to_string(), check);
         };
-        checks
+        checks_map
     }
 }
 

--- a/crates/omnix-health/src/check/rosetta.rs
+++ b/crates/omnix-health/src/check/rosetta.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nix_rs::{
     env::{AppleEmulation, MacOSArch, OS},
     info,
@@ -32,8 +30,8 @@ impl Checkable for Rosetta {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<&'static str, Check> {
-        let mut checks = HashMap::new();
+    ) -> Vec<(&'static str, Check)> {
+        let mut checks = vec![];
         if let (true, Some(emulation)) = (self.enable, get_apple_emulation(&nix_info.nix_env.os)) {
             let check = Check {
                 title: "Rosetta Not Active".to_string(),
@@ -48,7 +46,7 @@ impl Checkable for Rosetta {
                 },
                 required: self.required,
             };
-            checks.insert("rosetta", check);
+            checks.push(("rosetta", check));
         };
         checks
     }

--- a/crates/omnix-health/src/check/rosetta.rs
+++ b/crates/omnix-health/src/check/rosetta.rs
@@ -32,8 +32,8 @@ impl Checkable for Rosetta {
         &self,
         nix_info: &info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check> {
-        let mut checks_map = HashMap::new();
+    ) -> HashMap<&'static str, Check> {
+        let mut checks = HashMap::new();
         if let (true, Some(emulation)) = (self.enable, get_apple_emulation(&nix_info.nix_env.os)) {
             let check = Check {
                 title: "Rosetta Not Active".to_string(),
@@ -48,9 +48,9 @@ impl Checkable for Rosetta {
                 },
                 required: self.required,
             };
-            checks_map.insert("rosetta".to_string(), check);
+            checks.insert("rosetta", check);
         };
-        checks_map
+        checks
     }
 }
 

--- a/crates/omnix-health/src/check/shell.rs
+++ b/crates/omnix-health/src/check/shell.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
+    collections::HashMap, hash::Hash, path::{Path, PathBuf}
 };
 
 use crate::traits::{Check, CheckResult, Checkable};
@@ -27,9 +26,10 @@ impl Checkable for ShellCheck {
         &self,
         _nix_info: &nix_rs::info::NixInfo,
         _flake: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check> {
+    ) -> HashMap<String, Check> {
+        let mut checks_map = HashMap::new();
         if !self.enable {
-            return vec![];
+            return checks_map;
         }
         let user_shell_env = match CurrentUserShellEnv::new() {
             Ok(shell) => shell,
@@ -39,7 +39,7 @@ impl Checkable for ShellCheck {
                     panic!("Unable to determine user's shell environment (see above)");
                 } else {
                     tracing::warn!("Skipping shell dotfile check! (see above)");
-                    return vec![];
+                    return checks_map;
                 }
             }
         };
@@ -76,7 +76,8 @@ impl Checkable for ShellCheck {
             required: self.required,
         };
 
-        vec![check]
+        checks_map.insert("shell".to_string(), check);
+        checks_map
     }
 }
 

--- a/crates/omnix-health/src/check/shell.rs
+++ b/crates/omnix-health/src/check/shell.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap, hash::Hash, path::{Path, PathBuf}
+    collections::HashMap,
+    hash::Hash,
+    path::{Path, PathBuf},
 };
 
 use crate::traits::{Check, CheckResult, Checkable};
@@ -26,10 +28,10 @@ impl Checkable for ShellCheck {
         &self,
         _nix_info: &nix_rs::info::NixInfo,
         _flake: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check> {
-        let mut checks_map = HashMap::new();
+    ) -> HashMap<&'static str, Check> {
+        let mut checks = HashMap::new();
         if !self.enable {
-            return checks_map;
+            return checks;
         }
         let user_shell_env = match CurrentUserShellEnv::new() {
             Ok(shell) => shell,
@@ -39,7 +41,7 @@ impl Checkable for ShellCheck {
                     panic!("Unable to determine user's shell environment (see above)");
                 } else {
                     tracing::warn!("Skipping shell dotfile check! (see above)");
-                    return checks_map;
+                    return checks;
                 }
             }
         };
@@ -76,8 +78,8 @@ impl Checkable for ShellCheck {
             required: self.required,
         };
 
-        checks_map.insert("shell".to_string(), check);
-        checks_map
+        checks.insert("shell", check);
+        checks
     }
 }
 

--- a/crates/omnix-health/src/check/shell.rs
+++ b/crates/omnix-health/src/check/shell.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     hash::Hash,
     path::{Path, PathBuf},
 };
@@ -88,7 +88,7 @@ struct CurrentUserShellEnv {
     /// Current shell
     shell: Shell,
     /// *Absolute* paths to the dotfiles
-    dotfiles: BTreeMap<&'static str, PathBuf>,
+    dotfiles: HashMap<&'static str, PathBuf>,
 }
 
 impl CurrentUserShellEnv {
@@ -162,8 +162,8 @@ impl Shell {
     /// Get the currently existing dotfiles under $HOME
     ///
     /// Returned paths will be absolute (i.e., symlinks are resolved).
-    fn get_dotfiles(&self, home_dir: &Path) -> std::io::Result<BTreeMap<&'static str, PathBuf>> {
-        let mut paths = BTreeMap::new();
+    fn get_dotfiles(&self, home_dir: &Path) -> std::io::Result<HashMap<&'static str, PathBuf>> {
+        let mut paths = HashMap::new();
         for dotfile in self.dotfile_names() {
             match std::fs::canonicalize(home_dir.join(dotfile)) {
                 Ok(path) => {

--- a/crates/omnix-health/src/check/trusted_users.rs
+++ b/crates/omnix-health/src/check/trusted_users.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use nix_rs::config::TrustedUserValue;
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ impl Checkable for TrustedUsers {
         &self,
         nix_info: &nix_rs::info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check> {
+    ) -> HashMap<String, Check> {
         let result = if is_current_user_trusted(nix_info) {
             CheckResult::Green
         } else {
@@ -42,7 +42,10 @@ impl Checkable for TrustedUsers {
             result,
             required: true,
         };
-        vec![check]
+
+        let mut checks_map = HashMap::new();
+        checks_map.insert("trusted-users".to_string(), check);
+        checks_map
     }
 }
 

--- a/crates/omnix-health/src/check/trusted_users.rs
+++ b/crates/omnix-health/src/check/trusted_users.rs
@@ -15,7 +15,7 @@ impl Checkable for TrustedUsers {
         &self,
         nix_info: &nix_rs::info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check> {
+    ) -> HashMap<&'static str, Check> {
         let result = if is_current_user_trusted(nix_info) {
             CheckResult::Green
         } else {
@@ -43,9 +43,7 @@ impl Checkable for TrustedUsers {
             required: true,
         };
 
-        let mut checks_map = HashMap::new();
-        checks_map.insert("trusted-users".to_string(), check);
-        checks_map
+        [("trusted-users", check)].into_iter().collect()
     }
 }
 

--- a/crates/omnix-health/src/check/trusted_users.rs
+++ b/crates/omnix-health/src/check/trusted_users.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use nix_rs::config::TrustedUserValue;
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ impl Checkable for TrustedUsers {
         &self,
         nix_info: &nix_rs::info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<&'static str, Check> {
+    ) -> Vec<(&'static str, Check)> {
         let result = if is_current_user_trusted(nix_info) {
             CheckResult::Green
         } else {
@@ -43,7 +43,7 @@ impl Checkable for TrustedUsers {
             required: true,
         };
 
-        [("trusted-users", check)].into_iter().collect()
+        vec![("trusted-users", check)]
     }
 }
 

--- a/crates/omnix-health/src/lib.rs
+++ b/crates/omnix-health/src/lib.rs
@@ -85,33 +85,25 @@ impl NixHealth {
             .collect()
     }
 
-    pub async fn print_json_report_returning_exit_code(
-        checks_map: &HashMap<&'static str, Check>,
-    ) -> anyhow::Result<i32> {
-        let mut res = AllChecksResult::new();
-        for check in checks_map.values() {
-            if !check.result.green() {
-                res.register_failure(check.required);
-            };
-        }
-
-        let code = res.report();
-        println!("{}", serde_json::to_string_pretty(checks_map)?);
-        Ok(code)
-    }
-
     pub async fn print_report_returning_exit_code(
         checks_map: &HashMap<&'static str, Check>,
+        json_only: bool,
     ) -> anyhow::Result<i32> {
         let mut res = AllChecksResult::new();
         for check in checks_map.values() {
-            check.tracing_log().await?;
+            if !json_only {
+                check.tracing_log().await?;
+            }
             if !check.result.green() {
                 res.register_failure(check.required);
             };
         }
 
         let code = res.report();
+
+        if json_only {
+            println!("{}", serde_json::to_string_pretty(checks_map)?);
+        }
         Ok(code)
     }
 

--- a/crates/omnix-health/src/lib.rs
+++ b/crates/omnix-health/src/lib.rs
@@ -102,7 +102,7 @@ impl NixHealth {
         let code = res.report();
 
         if json_only {
-            println!("{}", serde_json::to_string_pretty(checks_map)?);
+            println!("{}", serde_json::to_string(checks_map)?);
         }
         Ok(code)
     }

--- a/crates/omnix-health/src/traits.rs
+++ b/crates/omnix-health/src/traits.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +9,7 @@ pub trait Checkable {
     /// Run and create the health check
     ///
     /// NOTE: Some checks may perform impure actions (IO, etc.). Returning an
-    /// empty vector indicates that the check is skipped on this environment.
+    /// empty hashmap indicates that the check is skipped on this environment.
     fn check(
         &self,
         nix_info: &nix_rs::info::NixInfo,
@@ -16,7 +18,7 @@ pub trait Checkable {
         // If None, the check is run against the current environment, with no
         // specific configuration from a flake.
         flake: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> Vec<Check>;
+    ) -> HashMap<String, Check>;
 }
 
 /// A health check

--- a/crates/omnix-health/src/traits.rs
+++ b/crates/omnix-health/src/traits.rs
@@ -18,7 +18,7 @@ pub trait Checkable {
         // If None, the check is run against the current environment, with no
         // specific configuration from a flake.
         flake: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<String, Check>;
+    ) -> HashMap<&'static str, Check>;
 }
 
 /// A health check

--- a/crates/omnix-health/src/traits.rs
+++ b/crates/omnix-health/src/traits.rs
@@ -7,7 +7,7 @@ pub trait Checkable {
     /// Run and create the health check
     ///
     /// NOTE: Some checks may perform impure actions (IO, etc.). Returning an
-    /// empty hashmap indicates that the check is skipped on this environment.
+    /// empty vector indicates that the check is skipped on this environment.
     fn check(
         &self,
         nix_info: &nix_rs::info::NixInfo,

--- a/crates/omnix-health/src/traits.rs
+++ b/crates/omnix-health/src/traits.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +16,7 @@ pub trait Checkable {
         // If None, the check is run against the current environment, with no
         // specific configuration from a flake.
         flake: Option<&nix_rs::flake::url::FlakeUrl>,
-    ) -> HashMap<&'static str, Check>;
+    ) -> Vec<(&'static str, Check)>;
 }
 
 /// A health check

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -12,6 +12,7 @@
   - Display information in Markdown
   - Remove RAM/disk space checks, moving them to "information" section
   - Add shell check, to ensure its dotfiles are managed by Nix.
+  - Add `--json` that returns the health check results as JSON
 - `om ci`
   - Support for remote builds over SSH (via `--on` option)
   - Support for CI steps


### PR DESCRIPTION
resolves #374 

```sh
❯ om health —json > health.json
❯ cat health.json
{
  "trusted-users": {
    "title": "Trusted Users",
    "info": "trusted-users = root shivaraj",
    "result": "Green",
    "required": true
  },
  "caches": {
    "title": "Nix Caches in use",
    "info": "substituters = https://cache.nixos.org/ https://euler.cachix.org/ https://newton.cachix.org/ https://om.cachix.org/",
    "result": "Green",
    "required": true
  },
  "max-jobs": {
    "title": "Max Jobs",
    "info": "max-jobs = 8",
    "result": "Green",
    "required": true
  },
  "nix-version": {
    "title": "Minimum Nix Version",
    "info": "nix version = 2.24.10",
    "result": "Green",
    "required": true
  },
  "rosetta": {
    "title": "Rosetta Not Active",
    "info": "apple emulation = None",
    "result": "Green",
    "required": true
  },
  "direnv-install-check": {
    "title": "Direnv installation",
    "info": "direnv location = Some(\"/Users/shivaraj/.nix-profile/bin/direnv\")",
    "result": "Green",
    "required": false
  },
  "shell": {
    "title": "Shell dotfiles",
    "info": "Shell=Zsh; HOME=\"/Users/shivaraj\"; Managed: {\".zshrc\": \"/nix/store/rxw82293y8b3nc65k2d49ji9i8kbc375-hm_.zshrc\", \".zshenv\": \"/nix/store/csica6diirv3swl0gqhwvpkyh8r7fhfw-hm_.zshenv\"}; Unmanaged: {\".zprofile\": \"/Users/shivaraj/.zprofile\"}",
    "result": {
      "Red": {
        "msg": "Default Shell: Zsh is not managed by Nix",
        "suggestion": "You can use `home-manager` to manage shell configuration. See <https://github.com/juspay/nixos-unified-template>"
      }
    },
    "required": false
  },
  "flake-enabled": {
    "title": "Flakes Enabled",
    "info": "experimental-features = flakes fetch-tree nix-command",
    "result": "Green",
    "required": true
  }
}
```