### PR TITLE
nix_rs/metadata: Account for cyclic inputs

### DIFF
--- a/crates/nix_rs/src/flake/metadata/flake.nix
+++ b/crates/nix_rs/src/flake/metadata/flake.nix
@@ -12,14 +12,21 @@
           # *All* nested inputs are flattened into a single list of inputs.
           inputs =
             let
-              inputsFor = prefix: f:
-                lib.concatLists (lib.mapAttrsToList
-                  (k: v: [{ name = "${prefix}__${k}"; path = v.outPath; }] ++
-                    (lib.optionals (lib.hasAttr "inputs" v))
-                      (inputsFor k v))
-                  f.inputs);
+              inputsFor = visited: prefix: f:
+                let
+                  here = builtins.unsafeDiscardStringContext "${f.outPath}";
+                in
+                # Keep track of visited nodes to workaround a nasty Nix design wart that leads to infinite recursion otherwise.
+                  # https://github.com/NixOS/nix/issues/7807
+                  # https://github.com/juspay/omnix/pull/389
+                lib.optionals (!lib.hasAttr here visited)
+                  (lib.concatLists (lib.mapAttrsToList
+                    (k: v: [{ name = "${prefix}__${k}"; path = v.outPath; }] ++
+                      (lib.optionals (lib.hasAttr "inputs" v))
+                        (inputsFor (visited // { "${here}" = true; }) "${prefix}/${k}" v))
+                    f.inputs));
             in
-            inputsFor "flake" inputs.flake;
+            inputsFor { } "flake" inputs.flake;
           flake = inputs.flake.outPath;
         });
       };


### PR DESCRIPTION
Resolves #388 

---

Several flakes in the wild abuse empty string (`""`) in their inputs follows, despite the fact that Nix treats these inputs as [referring to the containing flake](https://github.com/NixOS/nix/issues/7807#issuecomment-1427986568) which then leadds to infinite recursion in any naive code that traverses the flake inputs. This PR acounts for this case by skipping traversing those branches (by tracking visited nodes in the tree).

https://github.com/NixOS/nix/issues/7807

https://github.com/NixOS/nix/blob/ac31767c5725be8d363884a0e982c72af868590f/flake.nix#L18