### PR TITLE
`om health`: Add `info` in `json` output

### DIFF
--- a/crates/nix_rs/src/env.rs
+++ b/crates/nix_rs/src/env.rs
@@ -8,6 +8,7 @@ use std::{
 use bytesize::ByteSize;
 use os_info;
 use serde::{Deserialize, Serialize};
+use serde_with::SerializeDisplay;
 use std::process::Command;
 use tracing::instrument;
 use which::which;
@@ -93,7 +94,7 @@ fn get_nix_disk(sys: &sysinfo::System) -> Result<&sysinfo::Disk, NixEnvError> {
 }
 
 /// The system under which Nix is installed and operates
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDisplay, Deserialize)]
 pub enum OS {
     /// On macOS
     MacOS {

--- a/crates/omnix-cli/src/command/health.rs
+++ b/crates/omnix-cli/src/command/health.rs
@@ -25,7 +25,7 @@ impl HealthCommand {
             println!("{}", NixHealth::schema()?);
             return Ok(());
         }
-        let checks = run_all_checks_with(self.flake_url.clone()).await?;
+        let checks = run_all_checks_with(self.flake_url.clone(), self.json).await?;
         let exit_code = NixHealth::print_report_returning_exit_code(&checks, self.json).await?;
         if exit_code != 0 {
             std::process::exit(exit_code);

--- a/crates/omnix-health/src/json.rs
+++ b/crates/omnix-health/src/json.rs
@@ -1,0 +1,74 @@
+//! JSON output schema for health checks
+use crate::traits::Check;
+use anyhow::Context;
+use bytesize::ByteSize;
+use nix_rs::{detsys_installer::DetSysNixInstaller, env::OS, flake::system::System, info::NixInfo};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, path::PathBuf};
+
+/// Entire JSON health check output
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HealthOutput {
+    /// Map of check names to their results
+    pub checks: HashMap<String, Check>,
+    /// System environment information
+    pub info: HealthEnvInfo,
+}
+
+impl HealthOutput {
+    pub async fn get(checks: Vec<(&'static str, Check)>) -> anyhow::Result<Self> {
+        Ok(Self {
+            checks: checks
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+            info: HealthEnvInfo::get().await?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HealthEnvInfo {
+    nix_installer: NixInstaller,
+    system: System,
+    os: OS,
+    total_memory: ByteSize,
+    total_disk_space: ByteSize,
+}
+
+impl HealthEnvInfo {
+    /// Gathers current system environment information
+    ///
+    /// # Errors
+    /// Returns error if Nix information cannot be retrieved
+    pub async fn get() -> anyhow::Result<Self> {
+        let nix_info = NixInfo::get()
+            .await
+            .as_ref()
+            .context("Failed to gather Nix system information")?;
+
+        Ok(Self {
+            nix_installer: nix_info.nix_env.installer.clone().into(),
+            system: nix_info.nix_config.system.value.clone(),
+            os: nix_info.nix_env.os.clone(),
+            total_memory: nix_info.nix_env.total_memory,
+            total_disk_space: nix_info.nix_env.total_disk_space,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+enum NixInstaller {
+    DetSys(DetSysNixInstaller),
+    Other(PathBuf),
+}
+
+impl From<nix_rs::env::NixInstaller> for NixInstaller {
+    fn from(installer: nix_rs::env::NixInstaller) -> Self {
+        match installer {
+            nix_rs::env::NixInstaller::DetSys(installer) => Self::DetSys(installer),
+            nix_rs::env::NixInstaller::Other(path) => Self::Other(path),
+        }
+    }
+}

--- a/crates/omnix-health/src/json.rs
+++ b/crates/omnix-health/src/json.rs
@@ -37,15 +37,14 @@ pub struct HealthEnvInfo {
 }
 
 impl HealthEnvInfo {
-    /// Gathers current system environment information
+    /// Get system environment information
     ///
-    /// # Errors
-    /// Returns error if Nix information cannot be retrieved
+    /// Returns error if [NixInfo] cannot be retrieved
     pub async fn get() -> anyhow::Result<Self> {
         let nix_info = NixInfo::get()
             .await
             .as_ref()
-            .context("Failed to gather Nix system information")?;
+            .context("Unable to gather nix info")?;
 
         Ok(Self {
             nix_installer: nix_info.nix_env.installer.clone().into(),

--- a/crates/omnix-health/src/lib.rs
+++ b/crates/omnix-health/src/lib.rs
@@ -105,21 +105,22 @@ impl NixHealth {
                 .await
                 .as_ref()
                 .with_context(|| "Unable to gather nix info")?;
-            
+
             let sysinfo_json: serde_json::Value = vec![
                 ("system", nix_info.nix_config.system.value.to_string()),
                 ("os", nix_info.nix_env.os.to_string()),
                 ("nix-installer", nix_info.nix_env.installer.to_string()),
                 ("ram", nix_info.nix_env.total_memory.to_string()),
-                ("disk-space", nix_info.nix_env.total_disk_space.to_string())
-            ].into_iter().collect();
+                ("disk-space", nix_info.nix_env.total_disk_space.to_string()),
+            ]
+            .into_iter()
+            .collect();
 
             let checks: HashMap<_, _> = checks.iter().map(|(k, v)| (*k, v)).collect();
-            
-            let json: HashMap<_,_> = vec![
-                ("sysinfo", sysinfo_json),
-                ("checks", serde_json::to_value(checks)?),
-            ].into_iter().collect();
+
+            let mut json = HashMap::new();
+            json.insert("sysinfo", sysinfo_json);
+            json.insert("checks", serde_json::to_value(checks)?);
 
             println!("{}", serde_json::to_string(&json)?);
         }


### PR DESCRIPTION
Example output:
```json
{
  "checks": {
    "shell": {
      "title": "Shell dotfiles",
      "info": "Shell=Zsh; HOME=\"/Users/shivaraj\"; Managed: {\".zshenv\": \"/nix/store/csica6diirv3swl0gqhwvpkyh8r7fhfw-hm_.zshenv\", \".zshrc\": \"/nix/store/rxw82293y8b3nc65k2d49ji9i8kbc375-hm_.zshrc\"}; Unmanaged: {}",
      "result": "Green",
      "required": false
    },
    "flake-enabled": {
      "title": "Flakes Enabled",
      "info": "experimental-features = flakes fetch-tree nix-command",
      "result": "Green",
      "required": true
    },
    "supported-nix-versions": {
      "title": "Nix Version is supported",
      "info": "nix version = 2.24.10",
      "result": "Green",
      "required": true
    },
    "direnv-install-check": {
      "title": "Direnv installation",
      "info": "direnv location = Some(\"/Users/shivaraj/.nix-profile/bin/direnv\")",
      "result": "Green",
      "required": false
    },
    "rosetta": {
      "title": "Rosetta Not Active",
      "info": "apple emulation = false",
      "result": "Green",
      "required": true
    },
    "max-jobs": {
      "title": "Max Jobs",
      "info": "max-jobs = 8",
      "result": "Green",
      "required": true
    },
    "trusted-users": {
      "title": "Trusted Users",
      "info": "trusted-users = root shivaraj",
      "result": "Green",
      "required": true
    },
    "caches": {
      "title": "Nix Caches in use",
      "info": "substituters = https://cache.nixos.org/ https://euler.cachix.org/ https://newton.cachix.org/ https://om.cachix.org/",
      "result": "Green",
      "required": true
    }
  },
  "info": {
    "nix_installer": {
      "type": "DetSys",
      "version": {
        "major": 0,
        "minor": 16,
        "patch": 0
      }
    },
    "system": "aarch64-darwin",
    "os": "macOS",
    "total_memory": "17.2 GB",
    "total_disk_space": "493.9 GB"
  }
}
```