### PR TITLE
omresult: Capture allDeps (--print-all-dependencies)

### DIFF
--- a/crates/nix_rs/src/flake/functions/addstringcontext/flake.nix
+++ b/crates/nix_rs/src/flake/functions/addstringcontext/flake.nix
@@ -11,7 +11,7 @@
         let
           json = builtins.fromJSON (builtins.readFile inputs.jsonfile);
           jsonWithPathContext = lib.flip lib.mapAttrsRecursive json (k: v:
-            if lib.lists.last k == "outPaths" then
+            if lib.lists.last k == "outPaths" || lib.lists.last k == "allDeps" then
               builtins.map (path: builtins.storePath path) v
             else
               v


### PR DESCRIPTION
With this, `cachix push omresult` pushes the entire closure:

<img width="745" alt="image" src="https://github.com/user-attachments/assets/9e088d0d-b1e3-4296-80ea-745ad3f0138a" />

(As tested on vira)