### PR TITLE
`ci`: stdout should contain just the store path of the result JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "omnix-init",
  "predicates",
  "regex",
+ "serde",
  "serde_json",
  "tabled",
  "tokio",

--- a/crates/nix_rs/src/flake/functions/addstringcontext/mod.rs
+++ b/crates/nix_rs/src/flake/functions/addstringcontext/mod.rs
@@ -42,7 +42,7 @@ struct AddStringContextInput {
 pub async fn addstringcontext(
     cmd: &NixCmd,
     jsonfile: &Path,
-    out_link: &Path,
+    out_link: Option<&Path>,
 ) -> Result<PathBuf, super::core::Error> {
     const IMPURE: bool = true; // Our flake.nix uses builtin.storePath
 
@@ -52,6 +52,7 @@ pub async fn addstringcontext(
     let pwd = Some(jsonfile_parent);
 
     let current_pwd = std::env::current_dir()?;
+    let out_link_absolute: Option<PathBuf> = out_link.map(|p| current_pwd.join(p));
 
     let input = AddStringContextInput {
         jsonfile: FlakeUrl(format!("path:{}", jsonfile_name)),
@@ -61,7 +62,7 @@ pub async fn addstringcontext(
         false,
         IMPURE,
         pwd,
-        Some(&current_pwd.join(out_link)),
+        out_link_absolute.as_ref().map(PathBuf::as_ref),
         vec![],
         input,
     )

--- a/crates/omnix-ci/src/step/build.rs
+++ b/crates/omnix-ci/src/step/build.rs
@@ -65,8 +65,8 @@ impl BuildStep {
             all_deps: None,
         };
 
-        if run_cmd.steps_args.build_step_args.print_all_dependencies {
-            // Handle --print-all-dependencies
+        if run_cmd.steps_args.build_step_args.include_all_dependencies {
+            // Handle --include-all-dependencies
             let all_paths = NixStoreCmd
                 .fetch_all_deps(&res.devour_flake_output.out_paths)
                 .await?;
@@ -97,12 +97,12 @@ fn subflake_extra_args(subflake: &SubflakeConfig, build_step_args: &BuildStepArg
 /// CLI arguments for [BuildStep]
 #[derive(Parser, Debug, Clone)]
 pub struct BuildStepArgs {
-    /// Print build and runtime dependencies along with out paths
+    /// Include build and runtime dependencies along with out paths in the result JSON
     ///
-    /// By default, `om ci run` prints only the out paths. This option is
+    /// By default, `om ci run` includes only the out paths. This option is
     /// useful to explicitly push all dependencies to a cache.
     #[clap(long, short = 'd')]
-    pub print_all_dependencies: bool,
+    pub include_all_dependencies: bool,
 
     /// Additional arguments to pass through to `nix build`
     #[arg(last = true, default_values_t = vec![
@@ -118,8 +118,8 @@ impl BuildStepArgs {
     pub fn to_cli_args(&self) -> Vec<String> {
         let mut args = vec![];
 
-        if self.print_all_dependencies {
-            args.push("--print-all-dependencies".to_owned());
+        if self.include_all_dependencies {
+            args.push("--include-all-dependencies".to_owned());
         }
 
         if !self.extra_nix_build_args.is_empty() {

--- a/crates/omnix-ci/src/step/build.rs
+++ b/crates/omnix-ci/src/step/build.rs
@@ -144,17 +144,3 @@ pub struct BuildStepResult {
     #[serde(skip_serializing_if = "Option::is_none", rename = "allDeps")]
     pub all_deps: Option<Vec<StorePath>>,
 }
-
-impl BuildStepResult {
-    /// Print the result to stdout
-    pub fn print(&self) {
-        let paths = if let Some(paths) = &self.all_deps {
-            paths
-        } else {
-            &self.devour_flake_output.out_paths
-        };
-        for path in paths {
-            println!("{}", path.as_path().display());
-        }
-    }
-}

--- a/crates/omnix-ci/src/step/core.rs
+++ b/crates/omnix-ci/src/step/core.rs
@@ -75,7 +75,6 @@ impl Steps {
                 .build_step
                 .run(cmd, verbose, run_cmd, url, subflake)
                 .await?;
-            build_res.print();
             res.build_step = Some(build_res);
         }
 

--- a/crates/omnix-cli/Cargo.toml
+++ b/crates/omnix-cli/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 clap_complete = { workspace = true }
 clap_complete_nushell = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/omnix-cli/tests/command/ci.rs
+++ b/crates/omnix-cli/tests/command/ci.rs
@@ -3,11 +3,13 @@ use std::path::{Path, PathBuf};
 use anyhow::bail;
 use nix_rs::store::path::StorePath;
 use regex::Regex;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
 
 use super::core::om;
 
 /// Run `om ci run` passing given arguments, returning its stdout (parsed).
-async fn om_ci_run(args: &[&str]) -> anyhow::Result<Vec<StorePath>> {
+async fn om_ci_run(args: &[&str]) -> anyhow::Result<StorePath> {
     let mut cmd = om()?;
     cmd.arg("ci").arg("run").args(args);
 
@@ -19,27 +21,22 @@ async fn om_ci_run(args: &[&str]) -> anyhow::Result<Vec<StorePath>> {
         );
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let lines = stdout.lines();
-    let outs = lines
-        .map(|line| StorePath::new(PathBuf::from(line)))
-        .collect();
-    Ok(outs)
+    let out = StorePath::new(PathBuf::from(stdout.trim()));
+    Ok(out)
 }
 
 #[tokio::test]
 /// Run `om ci build` and check if the stdout consists of only /nix/store/* paths
 async fn build_flake_output() -> anyhow::Result<()> {
-    let outs =
+    let out =
         om_ci_run(&["github:srid/haskell-multi-nix/c85563721c388629fa9e538a1d97274861bc8321"])
             .await?;
 
-    for out in outs {
-        assert!(
-            out.as_path().starts_with("/nix/store/"),
-            "Unexpected line in stdout: {}",
-            out
-        );
-    }
+    assert!(
+        out.as_path().starts_with("/nix/store/"),
+        "Unexpected line in stdout: {}",
+        out
+    );
 
     Ok(())
 }
@@ -47,19 +44,11 @@ async fn build_flake_output() -> anyhow::Result<()> {
 #[tokio::test]
 /// A simple test, without config
 async fn test_haskell_multi_nix() -> anyhow::Result<()> {
-    let outs =
+    let out =
         om_ci_run(&["github:srid/haskell-multi-nix/c85563721c388629fa9e538a1d97274861bc8321"])
             .await?;
-    let drv_outs: Vec<PathBuf> = outs
-        .into_iter()
-        .filter_map(|drv_result| {
-            if let StorePath::Other(drv_out) = drv_result {
-                Some(drv_out)
-            } else {
-                None
-            }
-        })
-        .collect();
+    let v: Value = serde_json::from_reader(std::fs::File::open(&out)?)?;
+    let paths: Vec<PathBuf> = lookup_path(&v, &["result", "ROOT", "build", "outPaths"]).unwrap();
     let expected = vec![
         "/nix/store/3x2kpymc1qmd05da20wnmdyam38jkl7s-ghc-shell-for-packages-0",
         "/nix/store/dzhf0i3wi69568m5nvyckck8bbs9yrfd-foo-0.1.0.0",
@@ -69,43 +58,36 @@ async fn test_haskell_multi_nix() -> anyhow::Result<()> {
     .into_iter()
     .map(|s| PathBuf::from(s.to_string()))
     .collect::<Vec<_>>();
-    assert_same_drvs(drv_outs, expected);
+    assert_same_drvs(paths, expected);
     Ok(())
 }
 
 #[tokio::test]
 async fn test_haskell_multi_nix_all_dependencies() -> anyhow::Result<()> {
-    let outs = om_ci_run(&[
-        "--print-all-dependencies",
+    let out = om_ci_run(&[
+        "--include-all-dependencies",
         "github:srid/haskell-multi-nix/c85563721c388629fa9e538a1d97274861bc8321",
     ])
     .await?;
+    let v: Value = serde_json::from_reader(std::fs::File::open(&out)?)?;
+    let paths: Vec<PathBuf> = lookup_path(&v, &["result", "ROOT", "build", "allDeps"]).unwrap();
     // Since the number of dependencies is huge, we just check for the presence of system-independent
     // source of the `foo` sub-package in `haskell-multi-nix`.
-    let expected = StorePath::Other(PathBuf::from(
-        "/nix/store/bpybsny4gd5jnw0lvk5khpq7md6nwg5f-source-foo",
-    ));
-    assert!(outs.contains(&expected));
+    let expected = PathBuf::from("/nix/store/bpybsny4gd5jnw0lvk5khpq7md6nwg5f-source-foo");
+    assert!(paths.contains(&expected));
     Ok(())
 }
 
 #[tokio::test]
 /// A test, with config
 async fn test_services_flake() -> anyhow::Result<()> {
-    let outs = om_ci_run(&[
+    let out = om_ci_run(&[
         "github:juspay/services-flake/23cf162387af041035072ee4a9de20f8408907cb#default.simple-example",
     ])
     .await?;
-    let drv_outs: Vec<PathBuf> = outs
-        .into_iter()
-        .filter_map(|drv_result| {
-            if let StorePath::Other(drv_out) = drv_result {
-                Some(drv_out)
-            } else {
-                None
-            }
-        })
-        .collect();
+    let v: Value = serde_json::from_reader(std::fs::File::open(&out)?)?;
+    let paths: Vec<PathBuf> =
+        lookup_path(&v, &["result", "simple-example", "build", "outPaths"]).unwrap();
     let expected = vec![
         "/nix/store/ib83flb2pqjb416qrjbs4pqhifa3hhs4-default-test",
         "/nix/store/l9c8y2xx2iffk8l1ipp4mkval8wl8paa-default",
@@ -114,7 +96,7 @@ async fn test_services_flake() -> anyhow::Result<()> {
     .into_iter()
     .map(|s| PathBuf::from(s.to_string()))
     .collect::<Vec<_>>();
-    assert_same_drvs(drv_outs, expected);
+    assert_same_drvs(paths, expected);
     Ok(())
 }
 
@@ -137,4 +119,18 @@ pub fn without_hash(out_path: &Path) -> String {
     let re = Regex::new(r".+\-(.+)").unwrap();
     let captures = re.captures(out_path.to_str().unwrap()).unwrap();
     captures.get(1).unwrap().as_str().to_string()
+}
+
+/// Lookup a path in the [`serde_json::Value`]
+fn lookup_path<T>(v: &Value, path: &[&str]) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    match path {
+        [] => None,
+        [key] => v
+            .get(key)
+            .and_then(|v| serde_json::from_value(v.clone()).ok()),
+        [key, rest @ ..] => v.get(key).and_then(|v| lookup_path(v, rest)),
+    }
 }

--- a/doc/src/om/ci.md
+++ b/doc/src/om/ci.md
@@ -40,7 +40,7 @@ $ om ci run --on ssh://myname@myserver ~/code/myproject
 
 Just like `nix build`, `om ci` will produce a `result` symlink that contains a JSON of all store paths built. Use options `--out-link <PATH>` and `--no-link` to control this behaviour.
 
-As long as this symlink exists, your built paths will survive garbage collection.
+As long as this symlink exists, your built paths will survive garbage collection, because the closure of this symlink contains the entire build closure.
 
 ## Using in Github Actions {#gh}
 

--- a/doc/src/om/ci.md
+++ b/doc/src/om/ci.md
@@ -42,6 +42,14 @@ Just like `nix build`, `om ci` will produce a `result` symlink that contains a J
 
 As long as this symlink exists, your built paths will survive garbage collection, because the closure of this symlink contains the entire build closure.
 
+Note that in order to include all build dependencies, you should pass `--include-all-dependencies`, viz.:
+
+```
+om ci run --include-all-dependencies | xargs cachix push mycache
+```
+
+The above command will push the *entire* build closure (runtime and build dependencies) to the given cache.
+
 ## Using in Github Actions {#gh}
 
 In addition to serving the purpose of being a "local CI", `om ci` can be used in Github Actions to enable CI for your GitHub repositories.


### PR DESCRIPTION
`om ci run` now behaves like `nix build --print-out-paths` when it coms to what goes in STDOUT. Pipe it to `| cachix push` for easily pushing all paths to cachix (this includes build dependencies if `-d` was passed).

Also, rename `--print-all-dependencies` to `--include-all-dependencies` to better reflect the flag semantics. The short option, `-d`, remains the same.