### PR TITLE
feat(schema): Added schema for process-compose. [debug-based]

### DIFF
--- a/crates/omnix-cli/src/command/show.rs
+++ b/crates/omnix-cli/src/command/show.rs
@@ -146,6 +146,14 @@ impl ShowCommand {
                 self.flake_url
             )),
         );
+        print_flake_output_table(
+            "🔄 Process Compose",
+            &["allSystems", system.as_ref()],
+            Some(format!(
+                "nix run {}#<name>",
+                self.flake_url
+            )),
+        );
         print_flake_output_table("🔧 NixOS Modules", &["nixosModules"], None);
         print_flake_output_table(
             "🐳 Docker Images",

--- a/nix/flake-schemas/flake.nix
+++ b/nix/flake-schemas/flake.nix
@@ -79,6 +79,30 @@
             })
           output);
       };
+      processComposeSchema = {
+        version = 1;
+        doc = ''
+          The `apps` output provides commands available via `nix run`.
+        '';
+        inventory = output:
+          flake-schemas.lib.mkChildren (builtins.listToAttrs (map
+            (system: {
+              name = system;
+              value = flake-schemas.lib.mkChildren (builtins.mapAttrs
+                (processes: definition:
+                  {
+                    evalChecks.isValidProcess =
+                      definition ? settings &&
+                      definition ? package;
+                    derivation = definition.package;
+                    what = "Process Compose";
+                    evalOnAllSystems = true;
+                  })
+                (output.${system}.process-compose or { }));
+            })
+            [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ]));
+      };
+
     in
     {
       schemas = flake-schemas.schemas // {
@@ -87,6 +111,7 @@
         nixosConfigurations = nixosConfigurationsSchema;
         homeConfigurations = homeConfigurationsSchema;
         darwinConfigurations = darwinConfigurationsSchema;
+        allSystems = processComposeSchema;
       };
     };
 }


### PR DESCRIPTION
* Fully depended on debug flag of flake-parts.

To test make sure that the `debug` flag is true in a flake-parts flake.

e.g on [`juspay/services-flakes/example/llm`](https://github.com/juspay/services-flake/tree/main/example/llm) apply patch
```patch
diff --git a/example/llm/flake.nix b/example/llm/flake.nix
index c7ce558..a5cc377 100644
--- a/example/llm/flake.nix
+++ b/example/llm/flake.nix
@@ -8,6 +8,7 @@
     services-flake.url = "github:juspay/services-flake";
   };
   outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    debug = true;
     systems = import inputs.systems;
     imports = [
       inputs.process-compose-flake.flakeModule
```