### PR TITLE
Refactor arguments handling for `nix`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,11 +53,10 @@ jobs:
       # Run omnix using self.
       - name: Omnix CI
         run: |
-          nix run . -- ci \
+          nix run . -- ci run \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
-            run \
-              --systems "${{ matrix.system }}" \
-              --results=$HOME/omci.json
+            --systems "${{ matrix.system }}" \
+            --results=$HOME/omci.json
 
       - name: Omnix results
         id: omci
@@ -86,7 +85,7 @@ jobs:
       - name: Push to cachix
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         if: env.BRANCH_NAME == 'main'
         run: |
           nix run github:juspay/cachix-push -- \

--- a/crates/nix_rs/src/arg.rs
+++ b/crates/nix_rs/src/arg.rs
@@ -1,0 +1,73 @@
+//! Nix command's arguments
+
+use serde::{Deserialize, Serialize};
+
+/// All arguments you can pass to the `nix` command
+///
+/// This struct is clap-friendly for using in your subcommands. The clap options will mirror that of `nix`.
+///
+/// To convert to `Command` args list, use `into_iter`.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+pub struct NixArgs {
+    /// Append to the experimental-features setting of Nix.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub extra_experimental_features: Vec<String>,
+
+    /// Append to the access-tokens setting of Nix.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub extra_access_tokens: Vec<String>,
+
+    /// Consider all previously downloaded files out-of-date.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub refresh: bool,
+
+    /// Additional arguments to pass through to `nix`
+    #[arg(last = true, default_values_t = vec![
+    "-j".to_string(),
+    "auto".to_string(),
+    ])]
+    pub extra_nix_args: Vec<String>,
+}
+
+impl IntoIterator for &NixArgs {
+    type Item = String;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.to_args().into_iter()
+    }
+}
+
+impl NixArgs {
+    /// Convert this [NixCmd] configuration into a list of arguments for
+    /// [Command]
+    fn to_args(&self) -> Vec<String> {
+        let mut args = vec![];
+        if !self.extra_experimental_features.is_empty() {
+            args.push("--extra-experimental-features".to_string());
+            args.push(self.extra_experimental_features.join(" "));
+        }
+        if !self.extra_access_tokens.is_empty() {
+            args.push("--extra-access-tokens".to_string());
+            args.push(self.extra_access_tokens.join(" "));
+        }
+        if self.refresh {
+            args.push("--refresh".to_string());
+        }
+        args.extend(self.extra_nix_args.clone());
+        args
+    }
+
+    /// Enable flakes on this [NixCmd] configuration
+    pub fn with_flakes(&mut self) {
+        self.extra_experimental_features
+            .append(vec!["nix-command".to_string(), "flakes".to_string()].as_mut());
+    }
+
+    /// Enable nix-command on this [NixCmd] configuration
+    pub fn with_nix_command(&mut self) {
+        self.extra_experimental_features
+            .append(vec!["nix-command".to_string()].as_mut());
+    }
+}

--- a/crates/nix_rs/src/config.rs
+++ b/crates/nix_rs/src/config.rs
@@ -64,7 +64,7 @@ impl NixConfig {
         NIX_CONFIG
             .get_or_init(|| async {
                 let mut cmd = NixCmd::default();
-                cmd.with_nix_command(); // Enable nix-command, since don't yet know if it is already enabled.
+                cmd.args.with_nix_command(); // Enable nix-command, since don't yet know if it is already enabled.
                 let nix_ver = NixVersion::get().await.as_ref()?;
                 let cfg = NixConfig::from_nix(&cmd, nix_ver).await?;
                 Ok(cfg)

--- a/crates/nix_rs/src/lib.rs
+++ b/crates/nix_rs/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate exposes various types representing what nix command gives us,
 //! along with a `from_nix` command to evaluate them.
 #![warn(missing_docs)]
+pub mod arg;
 pub mod command;
 pub mod config;
 pub mod copy;

--- a/crates/omnix-ci/src/command/core.rs
+++ b/crates/omnix-ci/src/command/core.rs
@@ -1,7 +1,6 @@
 //! The `om ci` subcommands
 use clap::Subcommand;
 use colored::Colorize;
-use nix_rs::command::NixCmd;
 use omnix_common::config::OmConfig;
 use tracing::instrument;
 
@@ -29,14 +28,14 @@ impl Default for Command {
 impl Command {
     /// Run the command
     #[instrument(name = "run", skip(self))]
-    pub async fn run(self, nixcmd: &NixCmd, verbose: bool) -> anyhow::Result<()> {
+    pub async fn run(self, verbose: bool) -> anyhow::Result<()> {
         tracing::info!("{}", "\n👟 Reading om.ci config from flake".bold());
         let url = self.get_flake_ref().to_flake_url().await?;
         let cfg = OmConfig::get(&url).await?;
 
         tracing::debug!("OmConfig: {cfg:?}");
         match self {
-            Command::Run(cmd) => cmd.run(nixcmd, verbose, cfg).await,
+            Command::Run(cmd) => cmd.run(verbose, cfg).await,
             Command::DumpGithubActionsMatrix(cmd) => cmd.run(cfg).await,
         }
     }

--- a/crates/omnix-ci/src/command/run.rs
+++ b/crates/omnix-ci/src/command/run.rs
@@ -67,6 +67,10 @@ pub struct RunCommand {
     /// Arguments for all steps
     #[command(flatten)]
     pub steps_args: crate::step::core::StepsArgs,
+
+    /// Nix command global options
+    #[command(flatten)]
+    pub nixcmd: NixCmd,
 }
 
 impl Default for RunCommand {
@@ -96,15 +100,17 @@ impl RunCommand {
     }
 
     /// Run the build command which decides whether to do ci run on current machine or a remote machine
-    pub async fn run(&self, nixcmd: &NixCmd, verbose: bool, cfg: OmConfig) -> anyhow::Result<()> {
+    pub async fn run(&self, verbose: bool, cfg: OmConfig) -> anyhow::Result<()> {
         match &self.on {
-            Some(store_uri) => run_remote::run_on_remote_store(nixcmd, self, &cfg, store_uri).await,
-            None => self.run_local(nixcmd, verbose, cfg).await,
+            Some(store_uri) => {
+                run_remote::run_on_remote_store(&self.nixcmd, self, &cfg, store_uri).await
+            }
+            None => self.run_local(verbose, cfg).await,
         }
     }
 
     /// Run [RunCommand] on local Nix store.
-    async fn run_local(&self, nixcmd: &NixCmd, verbose: bool, cfg: OmConfig) -> anyhow::Result<()> {
+    async fn run_local(&self, verbose: bool, cfg: OmConfig) -> anyhow::Result<()> {
         // TODO: We'll refactor this function to use steps
         // https://github.com/juspay/omnix/issues/216
 
@@ -123,7 +129,7 @@ impl RunCommand {
             "{}",
             format!("\n🤖 Running CI for {}", self.flake_ref).bold()
         );
-        let res = ci_run(nixcmd, verbose, self, &cfg, &nix_info.nix_config).await?;
+        let res = ci_run(&self.nixcmd, verbose, self, &cfg, &nix_info.nix_config).await?;
 
         let m_out_link = self.get_out_link();
         let s = serde_json::to_string(&res)?;
@@ -134,7 +140,7 @@ impl RunCommand {
         path.write_all(s.as_bytes())?;
 
         let results_path =
-            addstringcontext::addstringcontext(nixcmd, path.path(), m_out_link).await?;
+            addstringcontext::addstringcontext(&self.nixcmd, path.path(), m_out_link).await?;
         println!("{}", results_path.display());
         if let Some(m_out_link) = m_out_link {
             tracing::info!(

--- a/crates/omnix-ci/src/step/build.rs
+++ b/crates/omnix-ci/src/step/build.rs
@@ -44,7 +44,7 @@ impl BuildStep {
             "{}",
             format!("⚒️  Building subflake: {}", subflake.dir).bold()
         );
-        let nix_args = subflake_extra_args(subflake, &run_cmd.steps_args.build_step_args);
+        let nix_args = subflake_extra_args(subflake);
         let output = DevourFlake::call(
             nixcmd,
             verbose,
@@ -78,7 +78,7 @@ impl BuildStep {
 }
 
 /// Extra args to pass to devour-flake
-fn subflake_extra_args(subflake: &SubflakeConfig, build_step_args: &BuildStepArgs) -> Vec<String> {
+fn subflake_extra_args(subflake: &SubflakeConfig) -> Vec<String> {
     let mut args = vec![];
 
     for (k, v) in &subflake.override_inputs {
@@ -88,8 +88,6 @@ fn subflake_extra_args(subflake: &SubflakeConfig, build_step_args: &BuildStepArg
             v.0.to_string(),
         ])
     }
-
-    args.extend(build_step_args.extra_nix_build_args.iter().cloned());
 
     args
 }
@@ -103,14 +101,6 @@ pub struct BuildStepArgs {
     /// useful to explicitly push all dependencies to a cache.
     #[clap(long, short = 'd')]
     pub include_all_dependencies: bool,
-
-    /// Additional arguments to pass through to `nix build`
-    #[arg(last = true, default_values_t = vec![
-    "--refresh".to_string(),
-    "-j".to_string(),
-    "auto".to_string(),
-    ])]
-    pub extra_nix_build_args: Vec<String>,
 }
 
 impl BuildStepArgs {
@@ -120,13 +110,6 @@ impl BuildStepArgs {
 
         if self.include_all_dependencies {
             args.push("--include-all-dependencies".to_owned());
-        }
-
-        if !self.extra_nix_build_args.is_empty() {
-            args.push("--".to_owned());
-            for arg in &self.extra_nix_build_args {
-                args.push(arg.clone());
-            }
         }
 
         args

--- a/crates/omnix-cli/src/command/ci.rs
+++ b/crates/omnix-cli/src/command/ci.rs
@@ -1,15 +1,10 @@
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Level, Verbosity};
-use nix_rs::command::NixCmd;
 use omnix_ci::command::core::Command;
 
 /// Build all outputs of the flake
 #[derive(Parser, Debug)]
 pub struct CICommand {
-    /// Nix command global options
-    #[command(flatten)]
-    pub nixcmd: NixCmd,
-
     #[clap(subcommand)]
     command: Option<Command>,
 }
@@ -18,7 +13,7 @@ impl CICommand {
     /// Run this sub-command
     pub async fn run(&self, verbosity: Verbosity<InfoLevel>) -> anyhow::Result<()> {
         self.command()
-            .run(&self.nixcmd, verbosity.log_level() > Some(Level::Info))
+            .run(verbosity.log_level() > Some(Level::Info))
             .await?;
         Ok(())
     }

--- a/doc/src/om/ci.md
+++ b/doc/src/om/ci.md
@@ -22,6 +22,9 @@ $ om ci # Or `om ci run` or `om ci run .`
 # Run CI on a local flake (default is $PWD)
 $ om ci run ~/code/myproject
 
+# Pass custom arguments to `nix` after '--'
+$ om ci run ~/code/myproject -- --accept-flake-config
+
 # Run CI on a github repo
 $ om ci run github:hercules-ci/hercules-ci-agent
 


### PR DESCRIPTION
For #416 

`NixCmd` now delegates to a `NixArgs` struct that encapsulates all argument passing to `nix`. This then gets used in `RunCommand` clap subcommand struct, such that `om ci run` (and only that) inherits these options, per the screenshot below.

Consequently, the following now works:

```
om ci run . -- --accept-flake-config
```

because now `--accept-flake-config` is passed in **all** invocations of `nix`. Eventually, in next PRs, we will do it for other subcommands as well (`develop`, `health`, etc.).

<img width="892" alt="image" src="https://github.com/user-attachments/assets/82249742-4533-40cd-adac-bd8faa0e62c3" />
