### PR TITLE
Add `NixArgs` to other commands

### DIFF
--- a/crates/omnix-ci/src/command/core.rs
+++ b/crates/omnix-ci/src/command/core.rs
@@ -1,6 +1,7 @@
 //! The `om ci` subcommands
 use clap::Subcommand;
 use colored::Colorize;
+use nix_rs::command::NixCmd;
 use omnix_common::config::OmConfig;
 use tracing::instrument;
 
@@ -31,12 +32,19 @@ impl Command {
     pub async fn run(self, verbose: bool) -> anyhow::Result<()> {
         tracing::info!("{}", "\n👟 Reading om.ci config from flake".bold());
         let url = self.get_flake_ref().to_flake_url().await?;
-        let cfg = OmConfig::get(&url).await?;
+        let cfg = OmConfig::get(self.nixcmd(), &url).await?;
 
         tracing::debug!("OmConfig: {cfg:?}");
         match self {
             Command::Run(cmd) => cmd.run(verbose, cfg).await,
             Command::DumpGithubActionsMatrix(cmd) => cmd.run(cfg).await,
+        }
+    }
+
+    fn nixcmd(&self) -> &NixCmd {
+        match self {
+            Command::Run(cmd) => &cmd.nixcmd,
+            Command::DumpGithubActionsMatrix(cmd) => &cmd.nixcmd,
         }
     }
 

--- a/crates/omnix-ci/src/command/gh_matrix.rs
+++ b/crates/omnix-ci/src/command/gh_matrix.rs
@@ -1,6 +1,6 @@
 //! The gh-matrix command
 use clap::Parser;
-use nix_rs::flake::system::System;
+use nix_rs::{command::NixCmd, flake::system::System};
 use omnix_common::config::OmConfig;
 
 use crate::{config::subflakes::SubflakesConfig, flake_ref::FlakeRef, github};
@@ -18,6 +18,10 @@ pub struct GHMatrixCommand {
     /// Systems to include in the matrix
     #[arg(long, value_parser, value_delimiter = ',')]
     pub systems: Vec<System>,
+
+    /// Nix command global options
+    #[command(flatten)]
+    pub nixcmd: NixCmd,
 }
 
 impl GHMatrixCommand {

--- a/crates/omnix-ci/src/config/core.rs
+++ b/crates/omnix-ci/src/config/core.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use nix_rs::flake::url::FlakeUrl;
+    use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
     use omnix_common::config::OmConfig;
 
     use crate::config::subflakes::SubflakesConfig;
@@ -15,7 +15,7 @@ mod tests {
             "github:srid/haskell-flake/c60351652c71ebeb5dd237f7da874412a7a96970#default.dev"
                 .to_string(),
         );
-        let cfg = OmConfig::get(url).await.unwrap();
+        let cfg = OmConfig::get(NixCmd::get().await, url).await.unwrap();
         let (config, attrs) = cfg.get_sub_config_under::<SubflakesConfig>("ci").unwrap();
         assert_eq!(attrs, &["dev"]);
         // assert_eq!(cfg.selected_subconfig, Some("dev".to_string()));

--- a/crates/omnix-cli/src/command/develop.rs
+++ b/crates/omnix-cli/src/command/develop.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use nix_rs::flake::url::FlakeUrl;
+use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 use omnix_common::config::OmConfig;
 
 /// Prepare to develop on a flake project
@@ -12,6 +12,10 @@ pub struct DevelopCommand {
     /// The stage to run in. If not provided, runs all stages.
     #[arg(long, value_enum)]
     stage: Option<Stage>,
+
+    /// Nix command global options
+    #[command(flatten)]
+    pub nixcmd: NixCmd,
 }
 
 /// The stage to run in
@@ -28,7 +32,7 @@ impl DevelopCommand {
     pub async fn run(&self) -> anyhow::Result<()> {
         let flake = self.flake_shell.without_attr();
 
-        let om_config = OmConfig::get(&flake).await?;
+        let om_config = OmConfig::get(&self.nixcmd, &flake).await?;
 
         tracing::info!("⌨️  Preparing to develop project: {:}", &flake);
         let prj = omnix_develop::core::Project::new(flake, om_config).await?;

--- a/crates/omnix-cli/src/command/health.rs
+++ b/crates/omnix-cli/src/command/health.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use nix_rs::flake::url::FlakeUrl;
+use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 use omnix_health::{run_all_checks_with, NixHealth};
 
 /// Display the health of your Nix dev environment
@@ -17,18 +17,23 @@ pub struct HealthCommand {
     /// Print output in JSON
     #[arg(long)]
     json: bool,
+
+    /// Nix command global options
+    #[command(flatten)]
+    pub nixcmd: NixCmd,
 }
 
 impl HealthCommand {
     pub async fn run(&self) -> anyhow::Result<()> {
         if self.dump_schema {
             println!("{}", NixHealth::schema()?);
-            return Ok(());
-        }
-        let checks = run_all_checks_with(self.flake_url.clone(), self.json).await?;
-        let exit_code = NixHealth::print_report_returning_exit_code(&checks, self.json).await?;
-        if exit_code != 0 {
-            std::process::exit(exit_code);
+        } else {
+            let checks =
+                run_all_checks_with(&self.nixcmd, self.flake_url.clone(), self.json).await?;
+            let exit_code = NixHealth::print_report_returning_exit_code(&checks, self.json).await?;
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
         }
         Ok(())
     }

--- a/crates/omnix-cli/src/command/show.rs
+++ b/crates/omnix-cli/src/command/show.rs
@@ -19,6 +19,10 @@ pub struct ShowCommand {
     /// The flake to show outputs for
     #[arg(name = "FLAKE")]
     pub flake_url: FlakeUrl,
+
+    /// Nix command global options
+    #[command(flatten)]
+    pub nixcmd: NixCmd,
 }
 
 /// Tabular representation of a set of flake outputs (eg: `packages.*`)
@@ -90,10 +94,9 @@ impl Row {
 
 impl ShowCommand {
     pub async fn run(&self) -> anyhow::Result<()> {
-        let nix_cmd = NixCmd::get().await;
         let nix_config = NixConfig::get().await.as_ref()?;
         let system = &nix_config.system.value;
-        let flake = Flake::from_nix(nix_cmd, nix_config, self.flake_url.clone())
+        let flake = Flake::from_nix(&self.nixcmd, nix_config, self.flake_url.clone())
             .await
             .with_context(|| "Unable to fetch flake")?;
 

--- a/crates/omnix-cli/tests/command/init.rs
+++ b/crates/omnix-cli/tests/command/init.rs
@@ -1,4 +1,4 @@
-use nix_rs::config::NixConfig;
+use nix_rs::{command::NixCmd, config::NixConfig};
 
 /// `om init` runs and successfully initializes a template
 #[tokio::test]
@@ -10,7 +10,7 @@ async fn om_init() -> anyhow::Result<()> {
         // TODO: Refactor(DRY) with src/core.rs:run_tests
         // TODO: Make this test (and other tests) use tracing!
         println!("🕍 Testing template: {}", url);
-        let templates = omnix_init::config::load_templates(url).await?;
+        let templates = omnix_init::config::load_templates(NixCmd::get().await, url).await?;
         for template in templates {
             let tests = &template.template.tests;
             for (name, test) in tests {

--- a/crates/omnix-health/src/lib.rs
+++ b/crates/omnix-health/src/lib.rs
@@ -11,6 +11,7 @@ use colored::Colorize;
 
 use check::direnv::Direnv;
 use json::HealthOutput;
+use nix_rs::command::NixCmd;
 use nix_rs::env::OS;
 use nix_rs::flake::url::FlakeUrl;
 use nix_rs::info::NixInfo;
@@ -114,6 +115,7 @@ impl NixHealth {
 
 /// Run all health checks, optionally using the given flake's configuration
 pub async fn run_all_checks_with(
+    nixcmd: &NixCmd,
     flake_url: Option<FlakeUrl>,
     json_only: bool,
 ) -> anyhow::Result<Vec<(&'static str, Check)>> {
@@ -124,7 +126,7 @@ pub async fn run_all_checks_with(
 
     let health: NixHealth = match flake_url.as_ref() {
         Some(flake_url) => {
-            let om_config = OmConfig::get(flake_url).await?;
+            let om_config = OmConfig::get(nixcmd, flake_url).await?;
             NixHealth::from_om_config(&om_config)
         }
         None => Ok(NixHealth::default()),

--- a/crates/omnix-init/src/config.rs
+++ b/crates/omnix-init/src/config.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use colored::Colorize;
-use nix_rs::flake::url::FlakeUrl;
+use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 use omnix_common::config::OmConfig;
 
 use crate::template::Template;
@@ -32,8 +32,11 @@ impl Display for FlakeTemplate<'_> {
 }
 
 /// Load templates from the given flake
-pub async fn load_templates(url: &FlakeUrl) -> anyhow::Result<Vec<FlakeTemplate>> {
-    let om_config = OmConfig::get(url).await?;
+pub async fn load_templates<'a>(
+    nixcmd: &'a NixCmd,
+    url: &'a FlakeUrl,
+) -> anyhow::Result<Vec<FlakeTemplate<'a>>> {
+    let om_config = OmConfig::get(nixcmd, url).await?;
 
     let templates = om_config
         .config

--- a/crates/omnix-init/src/core.rs
+++ b/crates/omnix-init/src/core.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, path::Path};
 
 use crate::config::{load_templates, FlakeTemplate};
 use anyhow::Context;
-use nix_rs::flake::{system::System, url::FlakeUrl};
+use nix_rs::{
+    command::NixCmd,
+    flake::{system::System, url::FlakeUrl},
+};
 use omnix_common::markdown::print_markdown;
 use serde_json::Value;
 
@@ -18,8 +21,12 @@ pub async fn select_from_registry() -> anyhow::Result<FlakeUrl> {
         .ok_or(anyhow::anyhow!("Flake not found in builtin registry"))
 }
 
-pub async fn run_tests(current_system: &System, flake: &FlakeUrl) -> anyhow::Result<()> {
-    let templates = load_templates(flake).await?;
+pub async fn run_tests(
+    nixcmd: &NixCmd,
+    current_system: &System,
+    flake: &FlakeUrl,
+) -> anyhow::Result<()> {
+    let templates = load_templates(nixcmd, flake).await?;
     for template in templates.iter() {
         tracing::info!("🕍 Testing template: {}#{}", flake, template.template_name);
         for (name, test) in template.template.tests.iter() {
@@ -50,12 +57,13 @@ pub async fn run_tests(current_system: &System, flake: &FlakeUrl) -> anyhow::Res
 /// - `default_params` - The default parameter values to use
 /// - `non_interactive` - Whether to disable user prompts (all params must have values set)
 pub async fn run(
+    nixcmd: &NixCmd,
     path: &Path,
     flake: &FlakeUrl,
     default_params: &HashMap<String, Value>,
     non_interactive: bool,
 ) -> anyhow::Result<()> {
-    let templates = load_templates(flake).await?;
+    let templates = load_templates(nixcmd, flake).await?;
     // Prompt the user to select a template
     let mut template: FlakeTemplate = if let Some(attr) = flake.get_attr().0 {
         templates


### PR DESCRIPTION
#416

om `develop`/`ci`/`health`/`init`/`show` - all of these inherit the same nix argument options now.

For example,

<img width="710" alt="image" src="https://github.com/user-attachments/assets/56e9629a-32e3-4971-98e4-27a16b31d5e1" />
