### PR TITLE
`om health`: Disable trusted-users check by default

### DIFF
--- a/crates/nix_rs/src/flake/url/core.rs
+++ b/crates/nix_rs/src/flake/url/core.rs
@@ -65,7 +65,7 @@ impl FlakeUrl {
         if let Some(path) = self.as_local_path() {
             Ok(path.to_path_buf())
         } else {
-            let (path, _) = FlakeMetadata::from_nix(
+            let (_, meta) = FlakeMetadata::from_nix(
                 cmd,
                 FlakeMetadataInput {
                     flake: self.clone(),
@@ -73,7 +73,7 @@ impl FlakeUrl {
                 },
             )
             .await?;
-            Ok(path)
+            Ok(meta.flake)
         }
     }
 

--- a/crates/omnix-common/src/config.rs
+++ b/crates/omnix-common/src/config.rs
@@ -49,6 +49,7 @@ impl OmConfig {
         .join("om.yaml");
 
         if !path.exists() {
+            tracing::debug!("{:?} does not exist; evaluating flake", path);
             return Ok(None);
         }
 

--- a/crates/omnix-health/src/check/trusted_users.rs
+++ b/crates/omnix-health/src/check/trusted_users.rs
@@ -8,7 +8,11 @@ use crate::traits::*;
 /// Check that [nix_rs::config::NixConfig::trusted_users] is set to a good value.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(default)]
-pub struct TrustedUsers {}
+pub struct TrustedUsers {
+    /// This check is disabled by default due to security concerns
+    /// See https://github.com/juspay/omnix/issues/409
+    pub(crate) enable: bool,
+}
 
 impl Checkable for TrustedUsers {
     fn check(
@@ -16,6 +20,9 @@ impl Checkable for TrustedUsers {
         nix_info: &nix_rs::info::NixInfo,
         _: Option<&nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<(&'static str, Check)> {
+        if !self.enable {
+            return vec![];
+        }
         let result = if is_current_user_trusted(nix_info) {
             CheckResult::Green
         } else {

--- a/doc/src/om/health.md
+++ b/doc/src/om/health.md
@@ -17,7 +17,6 @@ The `om health` command checks the health of your Nix install. Furthermore, indi
 | Nix runs natively (no rosetta)[^ros]   | Yes                          |
 | Builds use multiple cores (`max-jobs`) | Yes                          |
 | Nix Caches in use                      | Yes                          |
-| $USER is in `trusted-users`            | -                            |
 | Direnv: installed and activated        | Yes                          |
 | Dotfiles are managed by Nix            | Yes                          |
 | Min RAM / Disk space                   | Yes                          |
@@ -67,7 +66,8 @@ rosetta:
   enable: true
   required: true
 max-jobs: {}
-trusted-users: {}
+trusted-users:
+  enable: false
 caches:
   required:
     - https://cache.nixos.org/


### PR DESCRIPTION
Resolves #409

Also fixes a bug with reading `om.yaml` when argument is remote flake.

<img width="622" alt="image" src="https://github.com/user-attachments/assets/50c56914-4847-4b4c-979d-20a59884d90c" />
