### PR TITLE
chore: Switch to stable rust

### DIFF
--- a/crates/omnix-ci/src/command/run.rs
+++ b/crates/omnix-ci/src/command/run.rs
@@ -259,11 +259,11 @@ pub async fn ci_run(
     for (subflake_name, subflake) in &config.0 {
         let name = subflake_name.italic();
 
-        if let Some(s) = only_subflake
-            && s != subflake_name
-        {
-            tracing::info!("\n🍊 {} {}", name, "skipped (deselected out)".dimmed());
-            continue;
+        if let Some(s) = only_subflake {
+            if s != subflake_name {
+                tracing::info!("\n🍊 {} {}", name, "skipped (deselected out)".dimmed());
+                continue;
+            }
         }
 
         let compatible_system = subflake.can_run_on(&systems);

--- a/crates/omnix-ci/src/command/run_remote.rs
+++ b/crates/omnix-ci/src/command/run_remote.rs
@@ -213,10 +213,11 @@ async fn run_ssh(host: &str, args: &[String]) -> anyhow::Result<()> {
 
     nix_rs::command::trace_cmd_with("🐌", &cmd);
 
-    cmd.status()
-        .await?
-        .exit_ok()
-        .map_err(|e| anyhow::anyhow!("SSH command failed: {}", e))
+    let status = cmd.status().await?;
+    if !status.success() {
+        return Err(anyhow::anyhow!("SSH command failed: {}", status));
+    }
+    Ok(())
 }
 
 /// Run SSH command with given arguments and return the stdout.

--- a/crates/omnix-ci/src/lib.rs
+++ b/crates/omnix-ci/src/lib.rs
@@ -1,7 +1,5 @@
 //! omnix-ci: CI for Nix projects
 #![warn(missing_docs)]
-#![feature(exit_status_error)]
-#![feature(let_chains)]
 pub mod command;
 pub mod config;
 pub mod flake_ref;

--- a/crates/omnix-develop/src/lib.rs
+++ b/crates/omnix-develop/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(let_chains)]
 pub mod config;
 pub mod core;
 pub mod readme;

--- a/crates/omnix-health/src/lib.rs
+++ b/crates/omnix-health/src/lib.rs
@@ -150,7 +150,6 @@ pub async fn run_all_checks_with(
 
 async fn print_info_banner(flake_url: Option<&FlakeUrl>, nix_info: &NixInfo) -> anyhow::Result<()> {
     let pwd = std::env::current_dir()?;
-    let md = async |s: &str| render_markdown(&pwd, s).await;
 
     let mut table = String::from("| Property | Value |\n|----------|-------|\n");
     table.push_str(&format!(
@@ -177,7 +176,7 @@ async fn print_info_banner(flake_url: Option<&FlakeUrl>, nix_info: &NixInfo) -> 
         nix_info.nix_env.total_disk_space
     ));
 
-    tracing::info!("{}", md(&table).await?);
+    tracing::info!("{}", render_markdown(&pwd, &table).await?);
     Ok(())
 }
 

--- a/crates/omnix-health/src/traits.rs
+++ b/crates/omnix-health/src/traits.rs
@@ -43,25 +43,31 @@ impl Check {
     /// Log the results using tracing crate
     pub async fn tracing_log(&self) -> anyhow::Result<()> {
         let pwd = std::env::current_dir()?;
-        let md = async |s: &str| omnix_common::markdown::render_markdown(&pwd, s).await;
+        use omnix_common::markdown::render_markdown;
         match &self.result {
             CheckResult::Green => {
                 tracing::info!("✅ {}", self.title.green().bold());
-                tracing::info!("{}", md(&self.info).await?.dimmed());
+                tracing::info!("{}", render_markdown(&pwd, &self.info).await?.dimmed());
             }
             CheckResult::Red { msg, suggestion } => {
-                let solution = md(&format!(
-                    "**Problem**: {}\\\n**Fix**:     {}\n",
-                    msg, suggestion
-                ))
+                let solution = render_markdown(
+                    &pwd,
+                    &format!("**Problem**: {}\\\n**Fix**:     {}\n", msg, suggestion),
+                )
                 .await?;
                 if self.required {
-                    tracing::error!("❌ {}", md(&self.title).await?.red().bold());
-                    tracing::error!("{}", md(&self.info).await?.dimmed());
+                    tracing::error!(
+                        "❌ {}",
+                        render_markdown(&pwd, &self.title).await?.red().bold()
+                    );
+                    tracing::error!("{}", render_markdown(&pwd, &self.info).await?.dimmed());
                     tracing::error!("{}", solution);
                 } else {
-                    tracing::warn!("🟧 {}", md(&self.title).await?.yellow().bold());
-                    tracing::warn!("{}", md(&self.info).await?.dimmed());
+                    tracing::warn!(
+                        "🟧 {}",
+                        render_markdown(&pwd, &self.title).await?.yellow().bold()
+                    );
+                    tracing::warn!("{}", render_markdown(&pwd, &self.info).await?.dimmed());
                     tracing::warn!("{}", solution);
                 }
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]


### PR DESCRIPTION
required for https://github.com/NixOS/nixpkgs/pull/385761

We won’t have to revert async closure if we wait for https://github.com/NixOS/nixpkgs/pull/383902 to land in `nixos-unstable` (see https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html#async-closures)