### PR TITLE
chore: Define ENVs in a single nix file

### DIFF
--- a/crates/nix_rs/crate.nix
+++ b/crates/nix_rs/crate.nix
@@ -1,13 +1,3 @@
-{ flake
-, pkgs
-, lib
-, rust-project
-, ...
-}:
-
-let
-  inherit (flake) inputs;
-in
 {
   autoWire = [ ];
   crane = {
@@ -15,39 +5,6 @@ in
       nativeBuildInputs = [
         # nix # Tests need nix cli
       ];
-      DEFAULT_FLAKE_SCHEMAS = lib.cleanSourceWith {
-        name = "flake-schemas";
-        src = flake.inputs.self + /nix/flake-schemas;
-      };
-      FLAKE_METADATA = lib.cleanSourceWith {
-        name = "nix-rs-flake-metadata";
-        src = flake.inputs.self + /crates/nix_rs/src/flake/functions/metadata;
-      };
-      FLAKE_ADDSTRINGCONTEXT = lib.cleanSourceWith {
-        name = "nix-rs-flake-addstringcontext";
-        src = flake.inputs.self + /crates/nix_rs/src/flake/functions/addstringcontext;
-      };
-      INSPECT_FLAKE = inputs.inspect;
-      TRUE_FLAKE = inputs.true;
-      FALSE_FLAKE = inputs.false;
-      NIX_SYSTEMS = builtins.toJSON {
-        x86_64-linux = lib.cleanSourceWith {
-          name = "x86_64-linux";
-          src = inputs.nix-systems-x86_64-linux;
-        };
-        aarch64-linux = lib.cleanSourceWith {
-          name = "aarch64-linux";
-          src = inputs.nix-systems-aarch64-linux;
-        };
-        aarch64-darwin = lib.cleanSourceWith {
-          name = "aarch64-darwin";
-          src = inputs.nix-systems-aarch64-darwin;
-        };
-        x86_64-darwin = lib.cleanSourceWith {
-          name = "x86_64-darwin";
-          src = inputs.nix-systems-x86_64-darwin;
-        };
-      };
     };
   };
 }

--- a/crates/omnix-ci/crate.nix
+++ b/crates/omnix-ci/crate.nix
@@ -1,14 +1,7 @@
-{ flake
-, pkgs
+{ pkgs
 , lib
-, rust-project
 , ...
 }:
-
-let
-  inherit (flake) inputs;
-  inherit (inputs) self;
-in
 {
   autoWire = [ ];
   crane = {
@@ -32,23 +25,6 @@ in
       # Disable tests due to sandboxing issues; we run them on CI
       # instead.
       doCheck = false;
-      inherit (rust-project.crates."nix_rs".crane.args)
-        DEFAULT_FLAKE_SCHEMAS
-        FLAKE_METADATA
-        FLAKE_ADDSTRINGCONTEXT
-        INSPECT_FLAKE
-        TRUE_FLAKE
-        FALSE_FLAKE
-        NIX_SYSTEMS
-        ;
-      inherit (rust-project.crates."omnix-health".crane.args)
-        CACHIX_BIN
-        ;
-      DEVOUR_FLAKE = inputs.devour-flake;
-
-      # This value is set in omnix-cli/crate.nix.
-      # We use a dummy value here, however, to avoid unnecessarily rebuilding omnix-ci in CI
-      OMNIX_SOURCE = pkgs.hello;
     };
   };
 }

--- a/crates/omnix-cli/crate.nix
+++ b/crates/omnix-cli/crate.nix
@@ -1,12 +1,9 @@
-{ flake
-, rust-project
-, pkgs
+{ pkgs
 , lib
 , ...
 }:
 
 let
-  inherit (flake) inputs;
   inherit (pkgs) stdenv pkgsStatic;
 in
 {
@@ -34,27 +31,6 @@ in
         ) ++ lib.optionals pkgs.stdenv.isLinux [
         pkgsStatic.openssl
       ];
-
-      inherit (rust-project.crates."nix_rs".crane.args)
-        DEFAULT_FLAKE_SCHEMAS
-        FLAKE_METADATA
-        FLAKE_ADDSTRINGCONTEXT
-        INSPECT_FLAKE
-        TRUE_FLAKE
-        FALSE_FLAKE
-        NIX_SYSTEMS
-        ;
-      inherit (rust-project.crates."omnix-ci".crane.args)
-        DEVOUR_FLAKE
-        ;
-      inherit (rust-project.crates."omnix-init".crane.args)
-        OM_INIT_REGISTRY
-        ;
-      inherit (rust-project.crates."omnix-health".crane.args)
-        CACHIX_BIN
-        ;
-
-      OMNIX_SOURCE = rust-project.src;
 
       # Disable tests due to sandboxing issues; we run them on CI
       # instead.

--- a/crates/omnix-common/crate.nix
+++ b/crates/omnix-common/crate.nix
@@ -1,23 +1,3 @@
-{ flake
-, rust-project
-, pkgs
-, lib
-, ...
-}:
-
 {
   autoWire = [ ];
-  crane = {
-    args = {
-      inherit (rust-project.crates."nix_rs".crane.args)
-        DEFAULT_FLAKE_SCHEMAS
-        FLAKE_METADATA
-        FLAKE_ADDSTRINGCONTEXT
-        INSPECT_FLAKE
-        TRUE_FLAKE
-        FALSE_FLAKE
-        NIX_SYSTEMS
-        ;
-    };
-  };
 }

--- a/crates/omnix-develop/crate.nix
+++ b/crates/omnix-develop/crate.nix
@@ -1,9 +1,7 @@
 { pkgs
 , lib
-, rust-project
 , ...
 }:
-
 {
   autoWire = [ ];
   crane.args = {
@@ -12,17 +10,5 @@
         IOKit
       ]
     );
-    inherit (rust-project.crates."nix_rs".crane.args)
-      DEFAULT_FLAKE_SCHEMAS
-      FLAKE_METADATA
-      FLAKE_ADDSTRINGCONTEXT
-      INSPECT_FLAKE
-      TRUE_FLAKE
-      FALSE_FLAKE
-      NIX_SYSTEMS
-      ;
-    inherit (rust-project.crates."omnix-health".crane.args)
-      CACHIX_BIN
-      ;
   };
 }

--- a/crates/omnix-gui/crate.nix
+++ b/crates/omnix-gui/crate.nix
@@ -34,8 +34,6 @@ in
         dioxus-cli
         # pkgs.nix # cargo tests need nix
       ];
-      inherit (rust-project.crates."omnix-cli".crane.args)
-        DEFAULT_FLAKE_SCHEMAS;
       meta.description = "Graphical user interface for Omnix";
     };
   };

--- a/crates/omnix-health/crate.nix
+++ b/crates/omnix-health/crate.nix
@@ -1,13 +1,7 @@
-{ flake
-, pkgs
+{ pkgs
 , lib
-, rust-project
 , ...
 }:
-
-let
-  inherit (flake) inputs;
-in
 {
   autoWire = [ ];
   crane = {
@@ -18,22 +12,9 @@ in
           CoreFoundation
         ]
       );
-      inherit (rust-project.crates."nix_rs".crane.args)
-        DEFAULT_FLAKE_SCHEMAS
-        FLAKE_METADATA
-        FLAKE_ADDSTRINGCONTEXT
-        INSPECT_FLAKE
-        TRUE_FLAKE
-        FALSE_FLAKE
-        NIX_SYSTEMS
-        ;
-      CACHIX_BIN = pkgs.cachix + /bin/cachix;
       nativeBuildInputs = [
         # nix # Tests need nix cli
       ];
-    } // lib.optionalAttrs pkgs.stdenv.isLinux {
-      CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
-      CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
     };
   };
 }

--- a/crates/omnix-init/crate.nix
+++ b/crates/omnix-init/crate.nix
@@ -1,7 +1,5 @@
-{ flake
-, pkgs
+{ pkgs
 , lib
-, rust-project
 , ...
 }:
 
@@ -13,19 +11,5 @@
         IOKit
       ]
     );
-    inherit (rust-project.crates."nix_rs".crane.args)
-      DEFAULT_FLAKE_SCHEMAS
-      FLAKE_METADATA
-      FLAKE_ADDSTRINGCONTEXT
-      INSPECT_FLAKE
-      TRUE_FLAKE
-      FALSE_FLAKE
-      NIX_SYSTEMS
-      ;
-    OM_INIT_REGISTRY =
-      lib.cleanSourceWith {
-        name = "om-init-registry";
-        src = flake.inputs.self + /crates/omnix-init/registry;
-      };
   };
 }

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -5,6 +5,7 @@
 ### Chores
 
 - Allow building on stable version of Rust (#427)
+- Define ENVs in a single place and import them as default for all crates (#430)
 
 ## 1.0.0 (2025-02-17) {#1.0.0}
 

--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1741072947,
-        "narHash": "sha256-Rds9b8389PRvF1gS/XjrAEsJI5cddJjvB2Cgpnt4M84=",
+        "lastModified": 1741077589,
+        "narHash": "sha256-DL+4XiWzKS2fbHbzYuv0l5jLc3Gv0dBMDDXEcnPcAHM=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "997e3b3a64fcd50dfd93ab8c05d88e3e2985a8a8",
+        "rev": "c99c5a0af4090ea461d6a3793a256b8f3382ec3e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -217,15 +217,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1736806612,
-        "narHash": "sha256-WioA+Vk7suDK+Ek77rDlbuxV6WqwFt30JsKHrmDCSiU=",
+        "lastModified": 1741072947,
+        "narHash": "sha256-Rds9b8389PRvF1gS/XjrAEsJI5cddJjvB2Cgpnt4M84=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "b5f39885e2fcf137bfaf75decc077f9cca2bd984",
+        "rev": "997e3b3a64fcd50dfd93ab8c05d88e3e2985a8a8",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
+        "ref": "default-crane-args",
         "repo": "rust-flake",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -217,16 +217,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1741118494,
+        "lastModified": 1741121204,
         "narHash": "sha256-oMJsdsRzvO6l5oHqzXjhSe7D8ld06yAXwRPPrX/n/KI=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "7b3d424c26b6bcaa5885bd1214c13d89fe007a7d",
+        "rev": "ea753dade9e283809d11c63082840657eb766e97",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
-        "ref": "default-crane-args",
         "repo": "rust-flake",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1741077589,
-        "narHash": "sha256-DL+4XiWzKS2fbHbzYuv0l5jLc3Gv0dBMDDXEcnPcAHM=",
+        "lastModified": 1741118494,
+        "narHash": "sha256-oMJsdsRzvO6l5oHqzXjhSe7D8ld06yAXwRPPrX/n/KI=",
         "owner": "juspay",
         "repo": "rust-flake",
-        "rev": "c99c5a0af4090ea461d6a3793a256b8f3382ec3e",
+        "rev": "7b3d424c26b6bcaa5885bd1214c13d89fe007a7d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     systems.url = "github:nix-systems/default";
 
-    rust-flake.url = "github:juspay/rust-flake/default-crane-args";
+    rust-flake.url = "github:juspay/rust-flake";
     rust-flake.inputs.nixpkgs.follows = "nixpkgs";
     git-hooks.url = "github:cachix/git-hooks.nix";
     git-hooks.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     systems.url = "github:nix-systems/default";
 
-    rust-flake.url = "github:juspay/rust-flake";
+    rust-flake.url = "github:juspay/rust-flake/default-crane-args";
     rust-flake.inputs.nixpkgs.follows = "nixpkgs";
     git-hooks.url = "github:cachix/git-hooks.nix";
     git-hooks.flake = false;
@@ -31,6 +31,7 @@
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.systems;
+      debug = true;
 
       # See ./nix/modules/flake/*.nix for the modules that are imported here.
       imports = with builtins;

--- a/nix/envs/default.nix
+++ b/nix/envs/default.nix
@@ -1,5 +1,5 @@
 { src, lib, cachix, fetchFromGitHub }:
-{
+lib.mapAttrs (_: v: builtins.toString v) {
   OMNIX_SOURCE = src;
   CACHIX_BIN = lib.getExe cachix;
   OM_INIT_REGISTRY = lib.cleanSourceWith {

--- a/nix/envs/default.nix
+++ b/nix/envs/default.nix
@@ -1,0 +1,75 @@
+{ src, lib, cachix, fetchFromGitHub }:
+{
+  OMNIX_SOURCE = src;
+  CACHIX_BIN = lib.getExe cachix;
+  OM_INIT_REGISTRY = lib.cleanSourceWith {
+    name = "om-init-registry";
+    src = src + /crates/omnix-init/registry;
+  };
+  DEVOUR_FLAKE = fetchFromGitHub {
+    owner = "srid";
+    repo = "devour-flake";
+    rev = "9fe4db872c107ea217c13b24527b68d9e4a4c01b";
+    hash = "sha256-R7MHvTh5fskzxNLBe9bher+GQBZ8ZHjz75CPQG3fSRI=";
+  };
+  NIX_SYSTEMS =
+    let
+      x86_64-linux = fetchFromGitHub {
+        owner = "nix-systems";
+        repo = "x86_64-linux";
+        rev = "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8";
+        hash = "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=";
+      };
+      aarch64-linux = fetchFromGitHub {
+        owner = "nix-systems";
+        repo = "aarch64-linux";
+        rev = "aa1ce1b64c822dff925d63d3e771113f71ada1bb";
+        hash = "sha256-1Zp7TRYLXj4P5FLhQ8jBChrgAmQxR3iTypmWf9EFTnc=";
+      };
+      x86_64-darwin = fetchFromGitHub {
+        owner = "nix-systems";
+        repo = "x86_64-darwin";
+        rev = "db0463cce4cd60fb791f33a83d29a1ed53edab9b";
+        hash = "sha256-+xT9B1ZbhMg/zpJqd00S06UCZb/A2URW9bqqrZ/JTOg=";
+      };
+      aarch64-darwin = fetchFromGitHub {
+        owner = "nix-systems";
+        repo = "aarch64-darwin";
+        rev = "75e6c6912484d28ebba5769b794ffa4aff653ba2";
+        hash = "sha256-PHVNQ7y0EQYzujQRYoRdb96K0m1KSeAjSrbz2b75S6Q=";
+      };
+    in
+    builtins.toJSON {
+      inherit x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin;
+    };
+  FALSE_FLAKE = fetchFromGitHub {
+    owner = "boolean-option";
+    repo = "false";
+    rev = "d06b4794a134686c70a1325df88a6e6768c6b212";
+    hash = "sha256-vLy8GQr0noEcoA+jX24FgUVBA/poV36zDWAUChN3hIY=";
+  };
+  TRUE_FLAKE = fetchFromGitHub {
+    owner = "boolean-option";
+    repo = "true";
+    rev = "6ecb49143ca31b140a5273f1575746ba93c3f698";
+    hash = "sha256-L9eyTL7njtPBUYmZRYFKCzQFDgua9U9oE7UwCzjZfl8=";
+  };
+  INSPECT_FLAKE = fetchFromGitHub {
+    owner = "juspay";
+    repo = "inspect";
+    rev = "inventory-for-systems";
+    hash = "sha256-GTxRovvYWYn2/LDvjA73YttGuqvtKaOFZfOR9YxtST0=";
+  };
+  DEFAULT_FLAKE_SCHEMAS = lib.cleanSourceWith {
+    name = "flake-schemas";
+    src = src + /nix/flake-schemas;
+  };
+  FLAKE_METADATA = lib.cleanSourceWith {
+    name = "nix-rs-flake-metadata";
+    src = src + /crates/nix_rs/src/flake/functions/metadata;
+  };
+  FLAKE_ADDSTRINGCONTEXT = lib.cleanSourceWith {
+    name = "nix-rs-flake-addstringcontext";
+    src = src + /crates/nix_rs/src/flake/functions/addstringcontext;
+  };
+}

--- a/nix/modules/flake/rust.nix
+++ b/nix/modules/flake/rust.nix
@@ -72,7 +72,7 @@
       ];
       text = ''
         set -e
-        cd ${self'.packages.omnix-cli.OMNIX_SOURCE.outPath}
+        cd ${self'.packages.omnix-cli.OMNIX_SOURCE}
         # Make sure the drv evaluates (to test that no files are accidentally excluded)
         nix --accept-flake-config --extra-experimental-features "flakes nix-command" \
           derivation show "." | jq -r '.[].outputs.out.path'

--- a/nix/modules/flake/rust.nix
+++ b/nix/modules/flake/rust.nix
@@ -45,7 +45,10 @@
             || lib.hasSuffix "metadata/flake.lock" path
           ;
         };
-      defaultCraneArgs = import "${inputs.self}/nix/envs" { inherit (config.rust-project) src; inherit (pkgs) cachix fetchFromGitHub lib; };
+      defaults.perCrate.crane.args = import "${inputs.self}/nix/envs" {
+        inherit (config.rust-project) src;
+        inherit (pkgs) cachix fetchFromGitHub lib;
+      };
     };
 
     packages =

--- a/nix/modules/flake/rust.nix
+++ b/nix/modules/flake/rust.nix
@@ -42,6 +42,7 @@
             || lib.hasSuffix "addstringcontext/flake.lock" path
           ;
         };
+      defaultCraneArgs = pkgs.callPackage "${inputs.self}/nix/envs" { inherit (config.rust-project) src; };
     };
 
     packages =

--- a/nix/modules/flake/rust.nix
+++ b/nix/modules/flake/rust.nix
@@ -29,6 +29,7 @@
             || "${inputs.self}/flake.lock" == path
             || "${inputs.self}/rust-toolchain.toml" == path
             # Select *only* the non-Rust files necessary to build omnix package.
+            || lib.hasSuffix "envs/default.nix" path
             || lib.hasSuffix "flake/nixpkgs.nix" path
             || lib.hasSuffix "flake/rust.nix" path
             || lib.hasSuffix "tests/flake.nix" path
@@ -40,6 +41,8 @@
             || lib.hasSuffix "flake-schemas/flake.lock" path
             || lib.hasSuffix "addstringcontext/flake.nix" path
             || lib.hasSuffix "addstringcontext/flake.lock" path
+            || lib.hasSuffix "metadata/flake.nix" path
+            || lib.hasSuffix "metadata/flake.lock" path
           ;
         };
       defaultCraneArgs = import "${inputs.self}/nix/envs" { inherit (config.rust-project) src; inherit (pkgs) cachix fetchFromGitHub lib; };

--- a/nix/modules/flake/rust.nix
+++ b/nix/modules/flake/rust.nix
@@ -42,7 +42,7 @@
             || lib.hasSuffix "addstringcontext/flake.lock" path
           ;
         };
-      defaultCraneArgs = pkgs.callPackage "${inputs.self}/nix/envs" { inherit (config.rust-project) src; };
+      defaultCraneArgs = import "${inputs.self}/nix/envs" { inherit (config.rust-project) src; inherit (pkgs) cachix fetchFromGitHub lib; };
     };
 
     packages =


### PR DESCRIPTION
Avoids the need to explicitly define—and later maintain—these ENVs in nixpkgs while packaging for #204.

requires https://github.com/juspay/rust-flake/pull/33