### PR TITLE
ci: Remove 'Added input' filtering.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "nix_rs"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bytesize",
  "cfg-if",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "omnix-ci"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "omnix-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/nix_rs/Cargo.toml
+++ b/crates/nix_rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix_rs"
 # Important: remember to update the top-level Cargo.toml if updating major version
-version = "1.1.1"
+version = "1.1.2"
 license = "Apache-2.0"
 repository = "https://github.com/juspay/omnix"
 description = "Rust library for interacting with the Nix command"

--- a/crates/nix_rs/src/flake/functions/addstringcontext/mod.rs
+++ b/crates/nix_rs/src/flake/functions/addstringcontext/mod.rs
@@ -59,7 +59,6 @@ pub async fn addstringcontext(
     };
     let (path_with_string_context, _json_value) = AddStringContextFn::call(
         cmd,
-        false,
         IMPURE,
         pwd,
         out_link_absolute.as_ref().map(PathBuf::as_ref),

--- a/crates/nix_rs/src/flake/functions/metadata/mod.rs
+++ b/crates/nix_rs/src/flake/functions/metadata/mod.rs
@@ -67,6 +67,6 @@ impl FlakeMetadata {
         cmd: &NixCmd,
         input: FlakeMetadataInput,
     ) -> Result<(PathBuf, FlakeMetadata), super::core::Error> {
-        FlakeMetadataFn::call(cmd, false, false, None, None, vec![], input).await
+        FlakeMetadataFn::call(cmd, false, None, None, vec![], input).await
     }
 }

--- a/crates/omnix-ci/Cargo.toml
+++ b/crates/omnix-ci/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Sridhar Ratnakumar <srid@srid.ca>"]
 edition = "2021"
 # If you change the name here, you must also do it in flake.nix (and run `cargo generate-lockfile` afterwards)
 name = "omnix-ci"
-version = "1.0.1"
+version = "1.0.2"
 license = "AGPL-3.0-only"
 readme = "README.md"
 description = "Define and build CI for Nix projects anywhere"

--- a/crates/omnix-ci/src/command/core.rs
+++ b/crates/omnix-ci/src/command/core.rs
@@ -29,14 +29,14 @@ impl Default for Command {
 impl Command {
     /// Run the command
     #[instrument(name = "run", skip(self))]
-    pub async fn run(self, verbose: bool) -> anyhow::Result<()> {
+    pub async fn run(self) -> anyhow::Result<()> {
         tracing::info!("{}", "\n👟 Reading om.ci config from flake".bold());
         let url = self.get_flake_ref().to_flake_url().await?;
         let cfg = OmConfig::get(self.nixcmd(), &url).await?;
 
         tracing::debug!("OmConfig: {cfg:?}");
         match self {
-            Command::Run(cmd) => cmd.run(verbose, cfg).await,
+            Command::Run(cmd) => cmd.run(cfg).await,
             Command::DumpGithubActionsMatrix(cmd) => cmd.run(cfg).await,
         }
     }

--- a/crates/omnix-ci/src/step/build.rs
+++ b/crates/omnix-ci/src/step/build.rs
@@ -34,7 +34,6 @@ impl BuildStep {
     pub async fn run(
         &self,
         nixcmd: &NixCmd,
-        verbose: bool,
         run_cmd: &RunCommand,
         url: &FlakeUrl,
         subflake: &SubflakeConfig,
@@ -47,7 +46,6 @@ impl BuildStep {
         let nix_args = subflake_extra_args(subflake);
         let output = DevourFlake::call(
             nixcmd,
-            verbose,
             false,
             None,
             None,

--- a/crates/omnix-ci/src/step/core.rs
+++ b/crates/omnix-ci/src/step/core.rs
@@ -58,7 +58,6 @@ impl Steps {
     pub async fn run(
         &self,
         cmd: &NixCmd,
-        verbose: bool,
         run_cmd: &RunCommand,
         systems: &[System],
         url: &FlakeUrl,
@@ -71,10 +70,7 @@ impl Steps {
         }
 
         if self.build_step.enable {
-            let build_res = self
-                .build_step
-                .run(cmd, verbose, run_cmd, url, subflake)
-                .await?;
+            let build_res = self.build_step.run(cmd, run_cmd, url, subflake).await?;
             res.build_step = Some(build_res);
         }
 

--- a/crates/omnix-cli/Cargo.toml
+++ b/crates/omnix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnix-cli"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 default-run = "om"
 # NOTE: The 'description' here will be printed in `om` CLI banner (thanks to `clap` crate)

--- a/crates/omnix-cli/src/command/ci.rs
+++ b/crates/omnix-cli/src/command/ci.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use clap_verbosity_flag::{InfoLevel, Level, Verbosity};
 use omnix_ci::command::core::Command;
 
 /// Build all outputs of the flake
@@ -11,10 +10,8 @@ pub struct CICommand {
 
 impl CICommand {
     /// Run this sub-command
-    pub async fn run(&self, verbosity: Verbosity<InfoLevel>) -> anyhow::Result<()> {
-        self.command()
-            .run(verbosity.log_level() > Some(Level::Info))
-            .await?;
+    pub async fn run(&self) -> anyhow::Result<()> {
+        self.command().run().await?;
         Ok(())
     }
 

--- a/crates/omnix-cli/src/command/core.rs
+++ b/crates/omnix-cli/src/command/core.rs
@@ -1,5 +1,4 @@
 use clap::Subcommand;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
@@ -18,7 +17,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn run(&self, verbosity: Verbosity<InfoLevel>) -> anyhow::Result<()> {
+    pub async fn run(&self) -> anyhow::Result<()> {
         if !matches!(self, Command::Completion(_)) && !omnix_common::check::nix_installed() {
             tracing::error!("Nix is not installed: https://nixos.asia/en/install");
             std::process::exit(1);
@@ -28,7 +27,7 @@ impl Command {
             Command::Show(cmd) => cmd.run().await,
             Command::Init(cmd) => cmd.run().await,
             Command::Develop(cmd) => cmd.run().await,
-            Command::CI(cmd) => cmd.run(verbosity).await,
+            Command::CI(cmd) => cmd.run().await,
             Command::Health(cmd) => cmd.run().await,
             Command::Completion(cmd) => cmd.run(),
         }

--- a/crates/omnix-cli/src/main.rs
+++ b/crates/omnix-cli/src/main.rs
@@ -13,5 +13,5 @@ async fn main() -> anyhow::Result<()> {
     let verbose = args.verbosity.log_level() > Some(clap_verbosity_flag::Level::Info);
     omnix_common::logging::setup_logging(&args.verbosity, !verbose);
     tracing::debug!("Args: {:?}", args);
-    args.command.run(args.verbosity).await
+    args.command.run().await
 }

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -1,5 +1,12 @@
 # Release history
 
+## 1.0.2 (2025-03-11) {#1.0.2}
+
+### Fixes
+
+- `om ci`
+  - Prevent bad UTF-8 in build logs from crashing `om ci run` (#437)
+
 ## 1.0.1 (2025-03-10) {#1.0.1}
 
 ### Fixes


### PR DESCRIPTION
And pass STDERR as is to the user's terminal.

---

I don't think the complexity here is worth it for the slight benefit of keeping `om ci run`'s output less verbose. The ideal solution here is to fix upstream Nix to not spew out these messages if the user passes `--quiet --no-write-lock-file`. See here where it unconditionally writes this:

https://github.com/NixOS/nix/blob/8e8edb5bf857d62f7295c15534d2a4e555065fdf/src/libflake/flake/flake.cc#L906-L909

This change incidentally resolves #428