### PR TITLE
`om ci`: Allow impure builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "omnix-ci"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/omnix-ci/Cargo.toml
+++ b/crates/omnix-ci/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Sridhar Ratnakumar <srid@srid.ca>"]
 edition = "2021"
 # If you change the name here, you must also do it in flake.nix (and run `cargo generate-lockfile` afterwards)
 name = "omnix-ci"
-version = "1.0.2"
+version = "1.0.3"
 license = "AGPL-3.0-only"
 readme = "README.md"
 description = "Define and build CI for Nix projects anywhere"

--- a/crates/omnix-ci/src/step/build.rs
+++ b/crates/omnix-ci/src/step/build.rs
@@ -17,15 +17,23 @@ use crate::{
 /// Represents a build step in the CI pipeline
 ///
 /// It builds all flake outputs.
+///
+/// TODO: Should we use [`serde-bool`](https://docs.rs/serde-bool/latest/serde_bool/) to obviate that `Option` types in fields?
 #[derive(Debug, Clone, Deserialize)]
 pub struct BuildStep {
     /// Whether to enable this step
     pub enable: bool,
+    /// Whether to pass `--impure` to `nix build`
+    #[serde(default)]
+    pub impure: Option<bool>,
 }
 
 impl Default for BuildStep {
     fn default() -> Self {
-        BuildStep { enable: true }
+        BuildStep {
+            enable: true,
+            impure: None,
+        }
     }
 }
 
@@ -46,7 +54,7 @@ impl BuildStep {
         let nix_args = subflake_extra_args(subflake);
         let output = DevourFlake::call(
             nixcmd,
-            false,
+            self.impure.unwrap_or(false),
             None,
             None,
             nix_args,

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -1,5 +1,9 @@
 # Release history
 
+## 1.0.4 (UNRELEASED)
+
+- `om ci`: Allow impure builds through `impure = true;` setting in `om.yaml` (#445)
+
 ## 1.0.3 (2025-03-17) {#1.0.3}
 
 ### Fixes


### PR DESCRIPTION
To support legacy Nix (pre-flakes) `default.nix` projects, we can wrap them with a `flake.nix`, but because those old Nix expressions still use `builtins.currentSystem` it becomes imperative to run `nix build --impure`.

This supports that case for `om ci`, using the below configuration:

<img width="202" alt="image" src="https://github.com/user-attachments/assets/cc7bd3ba-4d05-46ec-8ae0-0f40cb14d140" />
