### PR TITLE
chore(cache): Change trusted-public-key

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   nixConfig = {
     extra-substituters = "https://cache.nixos.asia/oss";
-    extra-trusted-public-keys = "oss:w/g6Ylufxm7hqOztR1wIw+Ig73zSCYMtpMi83UwlPlA=";
+    extra-trusted-public-keys = "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=";
   };
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";


### PR DESCRIPTION
The cache state was destroyed along with the attic server