### PR TITLE
#455 fix : nix flake not enabled for determinate installer

### DIFF
--- a/crates/omnix-health/src/check/flake_enabled.rs
+++ b/crates/omnix-health/src/check/flake_enabled.rs
@@ -18,8 +18,12 @@ impl Checkable for FlakeEnabled {
         let check = Check {
             title: "Flakes Enabled".to_string(),
             info: format!("experimental-features = {}", val.join(" ")),
-            result: if val.contains(&"flakes".to_string())
-                && val.contains(&"nix-command".to_string())
+            // determinate installer has flakes enabled by default
+            result: if matches!(
+                nix_info.nix_env.installer,
+                nix_rs::env::NixInstaller::DetSys(_)
+            ) || (val.contains(&"flakes".to_string())
+                && val.contains(&"nix-command".to_string()))
             {
                 CheckResult::Green
             } else {


### PR DESCRIPTION
Nix `flakes` and `nix-command` is enabled by default for determinate nix installations. Do not check them in `experimental-features` list when determinate install is present.

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/4c92fc7c-d837-4871-bebb-b1881ca7cefa" />
