### PR TITLE
fix: wrong nix version being shown when Determinate Nix is being used

### DIFF
--- a/crates/nix_rs/src/version.rs
+++ b/crates/nix_rs/src/version.rs
@@ -43,7 +43,7 @@ impl FromStr for NixVersion {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // NOTE: The parser is lenient in allowing pure nix version (produced
         // by [Display] instance), so as to work with serde_with instances.
-        let re = Regex::new(r"(?:nix \(Nix\) )?(\d+)\.(\d+)\.(\d+)")?;
+        let re = Regex::new(r"(?:nix \(Nix\) )?(\d+)\.(\d+)\.(\d+)$")?;
 
         let captures = re.captures(s).ok_or(BadNixVersion::Command)?;
         let major = captures[1].parse::<u32>()?;

--- a/crates/nix_rs/src/version.rs
+++ b/crates/nix_rs/src/version.rs
@@ -114,4 +114,14 @@ async fn test_parse_nix_version() {
             patch: 0
         })
     );
+
+    // Parse Determinate Nix Version
+    assert_eq!(
+        NixVersion::from_str("nix (Determinate Nix 3.6.6) 2.29.0"),
+        Ok(NixVersion {
+            major: 2,
+            minor: 29,
+            patch: 0
+        })
+    );
 }

--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -3,6 +3,7 @@
 ## 1.0.4 (UNRELEASED)
 
 - `om ci`: Allow impure builds through `impure = true;` setting in `om.yaml` (#445)
+- `om health`: Fix DetSys installer hijacking its own version into `nix --version` causing false Nix version detection. (#458)
 
 ## 1.0.3 (2025-03-17) {#1.0.3}
 


### PR DESCRIPTION
This PR fixes the issue of wrong version being shown when running `om health`

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/7cd960da-f04b-4efe-80a6-fac045c9d339" />
