### PR TITLE
fix: replaced getExe with getExe' to avoid nix warning.

### DIFF
--- a/nix/envs/default.nix
+++ b/nix/envs/default.nix
@@ -1,7 +1,7 @@
 { src, lib, cachix, fetchFromGitHub }:
 lib.mapAttrs (_: v: builtins.toString v) {
   OMNIX_SOURCE = src;
-  CACHIX_BIN = lib.getExe cachix;
+  CACHIX_BIN = lib.getExe' cachix "cachix";
   OM_INIT_REGISTRY = "path:${src}/crates/omnix-init/registry";
   DEFAULT_FLAKE_SCHEMAS = "path:${src}/nix/flake-schemas";
   FLAKE_METADATA = "path:${src}/crates/nix_rs/src/flake/functions/metadata";


### PR DESCRIPTION
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/e1ef1526-52a6-4a79-977d-4a32bd237778" />

This will avoid this warning.