### PR TITLE
feature: Flake check for detSys installed nix

### DIFF
--- a/crates/nix_rs/src/config.rs
+++ b/crates/nix_rs/src/config.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::{
     command::{NixCmd, NixCmdError},
-    version::NixVersion,
+    version::{NixInstallationType, NixVersion},
 };
 
 use super::flake::system::System;
@@ -55,7 +55,7 @@ static NIX_2_20_0: NixVersion = NixVersion {
     major: 2,
     minor: 20,
     patch: 0,
-    is_detsys: false,
+    installation_type: NixInstallationType::Official,
 };
 
 impl NixConfig {

--- a/crates/nix_rs/src/config.rs
+++ b/crates/nix_rs/src/config.rs
@@ -55,6 +55,7 @@ static NIX_2_20_0: NixVersion = NixVersion {
     major: 2,
     minor: 20,
     patch: 0,
+    is_detsys: false,
 };
 
 impl NixConfig {

--- a/crates/nix_rs/src/version.rs
+++ b/crates/nix_rs/src/version.rs
@@ -18,6 +18,8 @@ pub struct NixVersion {
     pub minor: u32,
     /// Patch version
     pub patch: u32,
+    /// Whether this is a Determinate Systems Nix installation
+    pub is_detsys: bool,
 }
 
 /// Error type for parsing `nix --version`
@@ -43,17 +45,21 @@ impl FromStr for NixVersion {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // NOTE: The parser is lenient in allowing pure nix version (produced
         // by [Display] instance), so as to work with serde_with instances.
-        let re = Regex::new(r"(?:nix \(Nix\) )?(\d+)\.(\d+)\.(\d+)$")?;
+        let re = Regex::new(r"(?:nix \(.*?\) )?(\d+)\.(\d+)\.(\d+)$")?;
 
         let captures = re.captures(s).ok_or(BadNixVersion::Command)?;
         let major = captures[1].parse::<u32>()?;
         let minor = captures[2].parse::<u32>()?;
         let patch = captures[3].parse::<u32>()?;
 
+        // Check if this is a Determinate Systems Nix installation
+        let is_detsys = s.contains("Determinate");
+
         Ok(NixVersion {
             major,
             minor,
             patch,
+            is_detsys,
         })
     }
 }
@@ -101,7 +107,8 @@ async fn test_parse_nix_version() {
         Ok(NixVersion {
             major: 2,
             minor: 13,
-            patch: 0
+            patch: 0,
+            is_detsys: false
         })
     );
 
@@ -111,7 +118,8 @@ async fn test_parse_nix_version() {
         Ok(NixVersion {
             major: 2,
             minor: 13,
-            patch: 0
+            patch: 0,
+            is_detsys: false
         })
     );
 
@@ -121,7 +129,8 @@ async fn test_parse_nix_version() {
         Ok(NixVersion {
             major: 2,
             minor: 29,
-            patch: 0
+            patch: 0,
+            is_detsys: true
         })
     );
 }

--- a/crates/nix_rs/src/version_spec.rs
+++ b/crates/nix_rs/src/version_spec.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use thiserror::Error;
 
-use crate::version::NixVersion;
+use crate::version::{NixInstallationType, NixVersion};
 
 /// An individual component of [NixVersionReq]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -123,7 +123,7 @@ impl FromStr for NixVersionSpec {
             major,
             minor,
             patch,
-            is_detsys: false,
+            installation_type: NixInstallationType::Official,
         };
 
         match op {
@@ -175,7 +175,7 @@ mod tests {
                 major: 2,
                 minor: 8,
                 patch: 0,
-                is_detsys: false
+                installation_type: NixInstallationType::Official
             })
         );
         assert_eq!(
@@ -184,7 +184,7 @@ mod tests {
                 major: 2,
                 minor: 0,
                 patch: 0,
-                is_detsys: false
+                installation_type: NixInstallationType::Official
             })
         );
     }

--- a/crates/nix_rs/src/version_spec.rs
+++ b/crates/nix_rs/src/version_spec.rs
@@ -123,6 +123,7 @@ impl FromStr for NixVersionSpec {
             major,
             minor,
             patch,
+            is_detsys: false,
         };
 
         match op {
@@ -173,7 +174,8 @@ mod tests {
             NixVersionSpec::Gt(NixVersion {
                 major: 2,
                 minor: 8,
-                patch: 0
+                patch: 0,
+                is_detsys: false
             })
         );
         assert_eq!(
@@ -181,7 +183,8 @@ mod tests {
             NixVersionSpec::Gt(NixVersion {
                 major: 2,
                 minor: 0,
-                patch: 0
+                patch: 0,
+                is_detsys: false
             })
         );
     }

--- a/crates/omnix-health/src/check/flake_enabled.rs
+++ b/crates/omnix-health/src/check/flake_enabled.rs
@@ -55,3 +55,107 @@ impl Checkable for FlakeEnabled {
         vec![("flake-enabled", check)]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::CheckResult;
+    use nix_rs::{
+        config::{ConfigVal, NixConfig, TrustedUserValue},
+        flake::system::{Arch, System},
+        info::NixInfo,
+        version::NixVersion,
+    };
+    use url::Url;
+
+    fn mock_config_val<T: Clone>(value: T) -> ConfigVal<T> {
+        ConfigVal {
+            value: value.clone(),
+            default_value: value,
+            description: "Mock config value".to_string(),
+        }
+    }
+
+    fn mock_nix_config_without_flakes() -> NixConfig {
+        NixConfig {
+            cores: mock_config_val(4),
+            experimental_features: mock_config_val(vec!["auto-allocate-uids".to_string()]),
+            extra_platforms: mock_config_val(vec![]),
+            flake_registry: mock_config_val("https://flake-registry.example.com".to_string()),
+            max_jobs: mock_config_val(8),
+            substituters: mock_config_val(vec![Url::parse("https://cache.nixos.org/").unwrap()]),
+            system: mock_config_val(System::Linux(Arch::X86_64)),
+            trusted_users: mock_config_val(vec![TrustedUserValue::User("root".to_string())]),
+        }
+    }
+
+    fn mock_nix_config_with_flakes() -> NixConfig {
+        NixConfig {
+            cores: mock_config_val(4),
+            experimental_features: mock_config_val(vec![
+                "flakes".to_string(),
+                "nix-command".to_string(),
+            ]),
+            extra_platforms: mock_config_val(vec![]),
+            flake_registry: mock_config_val("https://flake-registry.example.com".to_string()),
+            max_jobs: mock_config_val(8),
+            substituters: mock_config_val(vec![Url::parse("https://cache.nixos.org/").unwrap()]),
+            system: mock_config_val(System::Linux(Arch::X86_64)),
+            trusted_users: mock_config_val(vec![TrustedUserValue::User("root".to_string())]),
+        }
+    }
+
+    async fn mock_nix_info(is_detsys: bool, has_flakes_config: bool) -> NixInfo {
+        let version = NixVersion {
+            major: 2,
+            minor: 29,
+            patch: 0,
+            is_detsys,
+        };
+        let config = if has_flakes_config {
+            mock_nix_config_with_flakes()
+        } else {
+            mock_nix_config_without_flakes()
+        };
+        NixInfo::new(version, config).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_flakes_enabled_with_detsys() {
+        let checker = FlakeEnabled::default();
+        let nix_info = mock_nix_info(true, false).await;
+        let results = checker.check(&nix_info, None);
+
+        assert_eq!(results.len(), 1);
+        let (_, check) = &results[0];
+        assert_eq!(check.title, "Flakes Enabled");
+        assert_eq!(check.info, "Flakes enabled via Determinate Systems Nix");
+        assert!(matches!(check.result, CheckResult::Green));
+    }
+
+    #[tokio::test]
+    async fn test_flakes_enabled_with_regular_nix_and_config() {
+        let checker = FlakeEnabled::default();
+        let nix_info = mock_nix_info(false, true).await;
+        let results = checker.check(&nix_info, None);
+
+        assert_eq!(results.len(), 1);
+        let (_, check) = &results[0];
+        assert_eq!(check.title, "Flakes Enabled");
+        assert_eq!(check.info, "experimental-features = flakes nix-command");
+        assert!(matches!(check.result, CheckResult::Green));
+    }
+
+    #[tokio::test]
+    async fn test_flakes_disabled_with_regular_nix() {
+        let checker = FlakeEnabled::default();
+        let nix_info = mock_nix_info(false, false).await;
+        let results = checker.check(&nix_info, None);
+
+        assert_eq!(results.len(), 1);
+        let (_, check) = &results[0];
+        assert_eq!(check.title, "Flakes Enabled");
+        assert_eq!(check.info, "experimental-features = auto-allocate-uids");
+        assert!(matches!(check.result, CheckResult::Red { .. }));
+    }
+}

--- a/crates/omnix-health/src/check/flake_enabled.rs
+++ b/crates/omnix-health/src/check/flake_enabled.rs
@@ -15,19 +15,40 @@ impl Checkable for FlakeEnabled {
         _: Option<&nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<(&'static str, Check)> {
         let val = &nix_info.nix_config.experimental_features.value;
-        let check = Check {
-            title: "Flakes Enabled".to_string(),
-            info: format!("experimental-features = {}", val.join(" ")),
-            result: if val.contains(&"flakes".to_string())
-                && val.contains(&"nix-command".to_string())
-            {
-                CheckResult::Green
-            } else {
+
+        // Check if flakes are enabled either through config or DetSys installation
+        let flakes_enabled = if nix_info.nix_version.is_detsys {
+            // Determinate Systems Nix has flakes enabled by default
+            true
+        } else {
+            // Check experimental-features config for regular Nix
+            val.contains(&"flakes".to_string()) && val.contains(&"nix-command".to_string())
+        };
+
+        let (info_msg, result) = if nix_info.nix_version.is_detsys {
+            (
+                "Flakes enabled via Determinate Systems Nix".to_string(),
+                CheckResult::Green,
+            )
+        } else if flakes_enabled {
+            (
+                format!("experimental-features = {}", val.join(" ")),
+                CheckResult::Green,
+            )
+        } else {
+            (
+                format!("experimental-features = {}", val.join(" ")),
                 CheckResult::Red {
                     msg: "Nix flakes are not enabled".into(),
                     suggestion: "See https://nixos.wiki/wiki/Flakes#Enable_flakes".into(),
-                }
-            },
+                },
+            )
+        };
+
+        let check = Check {
+            title: "Flakes Enabled".to_string(),
+            info: info_msg,
+            result,
             required: true,
         };
 


### PR DESCRIPTION
Resolves: #472 (based on the approach `2` mentioned in #472)

## On MacOs virtual Machine
<img width="854" height="467" alt="image" src="https://github.com/user-attachments/assets/91d86f57-f5fe-43ba-a7dd-3c0170340c50" />

## On Ubuntu virtual Machine (Simple Nix installation)
<img width="1298" height="620" alt="image" src="https://github.com/user-attachments/assets/e708e389-b55d-4816-8817-e6134b3a9cd2" />


## Commands used to test the package for backward compatibility.

- Run Version Parsing Tests: `cargo test --package nix_rs test_parse_nix_version`
- Run Flake Detection Tests: `cargo test --package omnix-health flake_enabled`
- Test Core Packages `cargo test --package nix_rs --package omnix-health`
- Build and Test Health Command `cargo build --bin om`
- Verify JSON Output `./target/debug/om health --json`

## Backward Compatibility
✅ No breaking changes - all existing functionality preserved
✅ Regular Nix installations continue to work as before
✅ Adds new capability without removing existing features

## Expected Behavior

- **DetSys Nix users**: Health check shows "✅ Flakes Enabled" with message "Flakes enabled via Determinate Systems Nix"
- **Regular Nix users**: Existing behavior unchanged - checks `experimental-features` config
