### PR TITLE
Combined: bump rand 0.8.6 + openssl 0.10.79 (PR #500 + #502)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,15 +2121,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2153,9 +2152,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
Combined branch to run CI on the union of two open dependabot PRs:

- #500 — build(deps): bump rand from 0.8.5 to 0.8.6
- #502 — build(deps): bump openssl from 0.10.72 to 0.10.79

Both merged cleanly into `main` (Cargo.lock-only changes).

## Test plan
- [ ] CI green on this combined branch
- [ ] If CI passes, merge the individual PRs (#500, #502) and close this draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)